### PR TITLE
Fix shell for users

### DIFF
--- a/puppet/modules/users/manifests/account.pp
+++ b/puppet/modules/users/manifests/account.pp
@@ -1,9 +1,10 @@
 define users::account($fullname) {
   user { $name:
-    ensure => present,
-    comment => $fullname,
-    home => "/home/$name",
+    ensure     => present,
+    comment    => $fullname,
+    home       => "/home/$name",
     managehome => true
+    shell      => '/bin/bash',
   }
 
   file { "/home/$name":


### PR DESCRIPTION
Having a shell of "/bin/sh" isn't particularly helpful, so setting the shell to bash. Also, we should do some sudo management - I can't sudo (to chsh or passwd) because I have no password in the first place ;)
