### PR TITLE
Add passwd hash sourced from Foreman

### DIFF
--- a/puppet/modules/users/manifests/account.pp
+++ b/puppet/modules/users/manifests/account.pp
@@ -1,10 +1,14 @@
-define users::account($fullname) {
+define users::account(
+  $fullname,
+  $passwd = undef
+) {
   user { $name:
     ensure     => present,
     comment    => $fullname,
     home       => "/home/$name",
     managehome => true,
     shell      => '/bin/bash',
+    passwd     => $passwd,
   }
 
   file { "/home/$name":

--- a/puppet/modules/users/manifests/init.pp
+++ b/puppet/modules/users/manifests/init.pp
@@ -1,26 +1,35 @@
-class users {
+class users (
+  $users  = undef
+) {
   file { "/root/.vimrc":
     ensure => present,
     source => "puppet:///modules/users/vimrc",
   }
 
-  users::account { "samkottler":
-    fullname => "Sam Kottler"
+  if $users == undef {
+    # Create basic users, delete once foreman is updated
+    users::account { "samkottler":
+      fullname => "Sam Kottler"
+    }
+
+    users::account { "gregsutcliffe":
+      fullname => "Greg Sutcliffe"
+    }
+
+    users::account { "ohadlevy":
+      fullname => "Ohad Levy"
+    }
+
+    users::account { "bgupta":
+      fullname => "Brian Gupta"
+    }
+
+    users::account { "dcleal":
+      fullname => "Dominic Cleal"
+    }
+  } else {
+    # Users hash is passed from Foreman
+    create_resources(users::account, $users)
   }
 
-  users::account { "gregsutcliffe":
-    fullname => "Greg Sutcliffe"
-  }
-
-  users::account { "ohadlevy":
-    fullname => "Ohad Levy"
-  }
-
-  users::account { "bgupta":
-    fullname => "Brian Gupta"
-  }
-
-  users::account { "dcleal":
-    fullname => "Dominic Cleal"
-  }
 }


### PR DESCRIPTION
Done as a full users hash, as a class param. This means:

a) We decouple the users from the manifests (apart from keys)
b) We can override the whole hash per-host if we need to add people to single hosts
c) We can add more things to the hash later (ssh keys, shells, etc)

Should remove the fallback code once we're happy it's working.
