### PR TITLE
Add new freight module in a temporary namespace for testing

### DIFF
--- a/puppet/modules/freight2/lib/puppet/parser/functions/ssh_keygen.rb
+++ b/puppet/modules/freight2/lib/puppet/parser/functions/ssh_keygen.rb
@@ -1,0 +1,60 @@
+# Forked from https://github.com/fup/puppet-ssh @ 59684a8ae174
+#
+# Arguments
+#   0: The keyname (e.g. id_rsa)
+#   1: (optional) the keytype to read (public or private)
+#
+module Puppet::Parser::Functions
+  newfunction(:ssh_keygen, :type => :rvalue) do |args|
+    args[1].nil? ? request = :public : request = args[1].to_sym
+
+    config = {
+      :ssh_dir      => 'ssh',
+      :ssh_comment  => args[0].chomp,
+      :ssh_key_type => 'rsa',
+
+    }
+
+    File.directory?('/etc/puppetlabs/puppet') ? config[:basedir] = '/etc/puppetlabs/puppet' : config[:basedir] = '/etc/puppet'
+
+    # Error Handling
+    unless args.length >= 1 then
+      raise Puppet::ParseError, "ssh_keygen(): wrong number of arguments (#{args.length}; must be > 1)"
+    end
+
+    unless (request == :public || request == :private) then
+      raise Puppet::ParseError, "ssh_keygen(): invalid key type (#{request}; must be 'public' or 'private')"
+    end
+
+    # Make sure to write out a directory to init if necessary
+    begin
+      if !File.directory?("#{config[:basedir]}/#{config[:ssh_dir]}")
+        Dir::mkdir("#{config[:basedir]}/#{config[:ssh_dir]}")
+      end
+    rescue => e
+      raise Puppet::ParseError, "ssh_keygen(): Unable to setup ssh keystore directory (#{e})"
+    end
+
+    # Do my keys exist? Well, keygen if they don't!
+    begin
+      unless File.exists?("#{config[:basedir]}/#{config[:ssh_dir]}/#{config[:ssh_comment]}") then
+        %x[/usr/bin/ssh-keygen -t #{config[:ssh_key_type]} -P '' -f #{config[:basedir]}/#{config[:ssh_dir]}/#{config[:ssh_comment]}]
+      end
+    rescue => e
+      raise Puppet::ParseError, "ssh_keygen(): Unable to generate ssh key (#{e})"
+    end
+
+    # Return ssh key content based on request
+    begin
+      case request
+      when :private
+        return File.open("#{config[:basedir]}/#{config[:ssh_dir]}/#{config[:ssh_comment]}").read
+      else
+        pub_key = File.open("#{config[:basedir]}/#{config[:ssh_dir]}/#{config[:ssh_comment]}.pub").read
+        return pub_key.scan(/^.* (.*) .*$/)[0][0]
+      end
+    rescue => e
+      raise Puppet::ParseError, "ssh_keygen(): Unable to read ssh #{request.to_s} key (#{e})"
+    end
+  end
+end

--- a/puppet/modules/freight2/manifests/client.pp
+++ b/puppet/modules/freight2/manifests/client.pp
@@ -1,0 +1,23 @@
+# Cheap class to deploy an SSH provate key for use in contacting the freight server
+# to upload deb packages for signing
+#
+class freight2::client {
+
+  $pub_key  = ssh_keygen('freight_key','public')
+  $priv_key = ssh_keygen('freight_key','private')
+
+  file { '/root/.ssh/id_freight':
+    owner   => 'root',
+    group   => 'root',
+    mode    => 0400,
+    content => "${priv_key}",
+  }
+
+  file { '/root/.ssh/id_freight.pub':
+    owner   => 'root',
+    group   => 'root',
+    mode    => 0644,
+    content => "ssh-rsa ${pub_key} freight_key\n",
+  }
+
+}

--- a/puppet/modules/freight2/manifests/config.pp
+++ b/puppet/modules/freight2/manifests/config.pp
@@ -1,0 +1,42 @@
+class freight2::config {
+
+  $freight_home = '/srv/freight'
+  $freight_user = 'freight'
+
+  # Setup the user, group, and ssh keys
+  class { 'freight2::user':
+    user => $freight_user,
+    home => $freight_home,
+  }
+
+  file { '/etc/freight.conf':
+    ensure  => present,
+    mode    => 644,
+    content => template('freight/freight.conf.erb'),
+    require => Package['freight'],
+  }
+
+  file { "${freight_home}/staged":
+    ensure => directory,
+    owner  => $freight_user,
+    group  => $freight_user,
+  }
+
+  file { "${freight_home}/web":
+    ensure => directory,
+    owner  => $freight_user,
+    group  => $freight_user,
+  }
+
+  file { "${freight_home}/rsync_cache":
+    ensure => directory,
+    owner  => $freight_user,
+    group  => $freight_user,
+  }
+
+  file { '/etc/cron.daily/freight':
+    mode    => 755,
+    content => template('freight/cron.erb'),
+  }
+
+}

--- a/puppet/modules/freight2/manifests/init.pp
+++ b/puppet/modules/freight2/manifests/init.pp
@@ -1,0 +1,20 @@
+# Freight toplevel class
+#
+# Dependencies
+#
+# * puppetlabs-apt
+#
+# Assumptions
+#
+#   Assumes ~freight/.gnupg exists and has the repo secret key loaded
+#
+# Further setup
+#
+#   You probably want to point a vhost at $freight_home
+#
+class freight2 {
+
+  class { 'freight2::install': }~>
+  class { 'freight2::config':  }
+
+}

--- a/puppet/modules/freight2/manifests/install.pp
+++ b/puppet/modules/freight2/manifests/install.pp
@@ -1,0 +1,22 @@
+class freight2::install {
+
+  if $::operatingsystem == 'Debian' {
+    apt::source { 'freight':
+      location    => 'http://packages.rcrowley.org',
+      release     => 'squeeze',
+      repos       => 'main',
+      key         => '7DF49CEF',
+      key_source  => 'http://packages.rcrowley.org/keyring.gpg',
+      include_src => false,
+    }->
+    package { 'freight':
+      ensure  => installed,
+    }
+  } else {
+    package { 'freight':
+      ensure   => installed,
+      provider => 'gem'
+    }
+  }
+
+}

--- a/puppet/modules/freight2/manifests/user.pp
+++ b/puppet/modules/freight2/manifests/user.pp
@@ -1,0 +1,60 @@
+class freight2::user (
+  $user = 'freight',
+  $home = '/srv/freight',
+) {
+
+  # Disable password, we want this to be keys only
+  user { $user:
+    ensure     => present,
+    home       => $home,
+    managehome => true,
+    password   => '!',
+  }
+
+  file { $home:
+    ensure => directory,
+    owner  => $user,
+    group  => $user,
+    mode   => 0755,
+  }
+
+  file { "${home}/.ssh":
+    ensure => directory,
+    owner  => $user,
+    group  => $user,
+    mode   => 0700,
+  }
+
+  file { "${home}/.ssh/authorized_keys":
+    ensure => present,
+    owner  => $user,
+    group  => $user,
+    mode   => 0644,
+  }
+
+  # Read the dirvish key from the puppetmaster
+  $pub_key  = ssh_keygen('freight_key','public')
+
+  file_line { 'freight_ssh_public':
+    ensure => present,
+    path   => "${home}/.ssh/authorized_keys",
+    line   => "command=\"${home}/bin/freight_rsync\" ssh-rsa ${pub_key} freight_key\n",
+  }
+
+  # Create validation script for rsync connections only
+  file { "${home}/bin":
+    ensure => directory,
+    owner  => $user,
+    group  => $user,
+    mode   => 0755,
+  }
+
+  file { "${home}/bin/freight_rsync":
+    ensure  => present,
+    owner   => $user,
+    group   => $user,
+    mode    => 0755,
+    content => template('freight/rsync.erb'),
+  }
+
+}

--- a/puppet/modules/freight2/templates/cron.erb
+++ b/puppet/modules/freight2/templates/cron.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean up old nightlies from freight
+
+# This won't actually remove them, but the next time freight-cache runs
+# (.e. when the next nightly is built) they will be removed from the web repo
+
+. /etc/freight.conf
+
+find $VARLIB -mtime +6 -iname "*nightly*deb" -delete

--- a/puppet/modules/freight2/templates/freight.conf.erb
+++ b/puppet/modules/freight2/templates/freight.conf.erb
@@ -1,0 +1,15 @@
+# Example Freight configuration.
+
+# Directories for the Freight library and Freight cache.  Your web
+# server's document root should be `$VARCACHE`.
+VARLIB="<%= freight_home %>/staged"
+VARCACHE="<%= freight_home %>/web"
+
+# Default `Origin` and `Label` fields for `Release` files.
+ORIGIN="TheForeman"
+LABEL="TheForeman"
+
+# GPG key to use to sign repositories.  This is required by the `apt`
+# repository provider.  Use `gpg --gen-key` (see `gpg`(1) for more
+# details) to generate a key and put its email address here.
+GPG="packages@theforeman.org"

--- a/puppet/modules/freight2/templates/rsync.erb
+++ b/puppet/modules/freight2/templates/rsync.erb
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+case "$SSH_ORIGINAL_COMMAND" in
+*\&*)
+echo "Rejected"
+;;
+*\(*)
+echo "Rejected"
+;;
+*\{*)
+echo "Rejected"
+;;
+*\;*)
+echo "Rejected"
+;;
+*\<*)
+echo "Rejected"
+;;
+*\`*)
+echo "Rejected"
+;;
+*\|*)
+echo "Rejected"
+;;
+rsync\ --server*)
+# Only push to the rsync cache
+if [ `echo $SSH_ORIGINAL_COMMAND | awk '{ print $NF }'` == 'rsync_cache/' ] ; then
+  $SSH_ORIGINAL_COMMAND
+  # TODO: work out how to handle the paths-to-repo mapping
+  find /srv/freight/rsync_cache/ -iname '*.deb' -exec freight-add {} apt/squeeze/stable \;
+  # Publish the debs
+  freight-cache -v
+  # Cleanup - no need to keep the debs
+  find /srv/freight/rsync_cache/ -iname '*.deb' -delete
+fi
+;;
+*)
+echo "Rejected"
+;;
+esac


### PR DESCRIPTION
This is in the 'freight2' namespace so we don't break the freight module running on server09.

This module is intended to run on the web node (server2) and configures:
- freight package
- a freight user
- an SSH key to access the freight homedir
- a restrictive wrapper which only allows rsync to ~/rsync_cache
- the wrapper also performs the freight-add / freight-cache actions on incoming debs

The 'freight::client' class goes on the uploader (server09, eventually) and simply deploys the private part of the SSH key so it can push to freight@server. That key should probably go into ~jenkins later, but for testing it's in ~root

We need to test this by applying it to server2, adding the freight::client to server09, and then trying to push debs to server2. There's more work to do on how to process the incoming debs into the right pools, but that can be tested once this transport is working properly.
