### PR TITLE
Add rsync globally

### DIFF
--- a/puppet/modules/utility/manifests/init.pp
+++ b/puppet/modules/utility/manifests/init.pp
@@ -18,4 +18,8 @@ class utility {
   package { "screen":
     ensure => present
   }
+
+  package { "rsync":
+    ensure => present
+  }
 }


### PR DESCRIPTION
I discovered the webnode didn't have rsync. Given it's just the best way to transfer files, I thought we should fix that everywhere :)
