### PR TITLE
Add puppetlabs repo to all deb systems, use it to ensure the right puppet version

### DIFF
--- a/puppet/modules/utility/manifests/init.pp
+++ b/puppet/modules/utility/manifests/init.pp
@@ -1,6 +1,8 @@
 class utility {
   include motd
 
+  class { 'utility::repos': }
+
   package { "vim":
     ensure => present,
     name => $osfamily ? {
@@ -32,4 +34,17 @@ class utility {
       default => "ruby-shadow"
     }
   }
+
+  # This can be expanded to include yum systems later
+  case $::operatingsystem {
+    fedora,redhat,centos,Scientific: {}
+    Debian,Ubuntu: {
+      package { ['puppet-common','puppet']:
+        ensure  => '2.7.21-1puppetlabs1',
+        require => Apt::Source['puppetlabs'],
+      }
+    }
+    default: {}
+  }
+
 }

--- a/puppet/modules/utility/manifests/repos.pp
+++ b/puppet/modules/utility/manifests/repos.pp
@@ -1,0 +1,16 @@
+class utility::repos {
+
+  # This can be expanded to include yum systems later
+  case $::operatingsystem {
+    fedora,redhat,centos,Scientific: {}
+    Debian,Ubuntu: {
+      apt::source { 'puppetlabs':
+        location   => 'http://apt.puppetlabs.com',
+        repos      => 'main',
+        key        => '4BD6EC30',
+        key_server => 'pgp.mit.edu',
+      }
+    }
+    default: {}
+  }
+}


### PR DESCRIPTION
There are a bunch of infra machines running from gem instead of packages, and in some cases both are installed. This causes much confusion.

This adds the puppetlabs repo so we can pick any version we like. I've gone with 2.7.latest for now, we can move up to 3.1.0 whenever we like.

Hopefully one of you will add yum support too ;)
