### PR TITLE
Add initial RBot module

### DIFF
--- a/puppet/modules/munin/files/munin-node.conf
+++ b/puppet/modules/munin/files/munin-node.conf
@@ -1,5 +1,5 @@
 log_level 4
-log_file /var/log/munin/munin-node.log
+log_file /var/log/munin-node/munin-node.log
 pid_file /var/run/munin/munin-node.pid
 
 background 1


### PR DESCRIPTION
This would be applied with an enc like:

```
class { 'rbot':
    nickname => 'nudnik',
    servers  => ['chat.eu.freenode.net','irc.ubuntu.com'],
    channels => ['#theforeman','#katello','#theforeman-dev'],
}
```

(The channels and servers have been copied from nudnik's current config file, I'm not sure if the ubuntu server is required)

Before we apply it, we'd want to copy nudnik's current config file from shell. That isn't (currently) managed by puppet, only the skeleton seed file is, because rbot will update it's config file on the fly. We can add the whole current config file to puppet if people think that's a good idea.
