### PR TITLE
Use rpm-packaged logdir for munin-node

### DIFF
--- a/puppet/modules/munin/files/munin-node.conf
+++ b/puppet/modules/munin/files/munin-node.conf
@@ -1,6 +1,6 @@
 log_level 4
-log_file /var/log/munin/munin-node.log
-pid_file /var/run/munin/munin-node.pid
+log_file /var/log/munin-node/munin-node.log
+pid_file /var/run/munin-node.pid
 
 background 1
 setsid 1


### PR DESCRIPTION
The rpm uses a different logdir for munin-node:

```
[root@server12 ~]# rpm -ql munin-node|grep log/
/var/log/munin-node
```

Without this, a fresh build tries to log to `/var/log/munin` and gets in a reboot loop.

Also records PID to a file in `/var/run` to avoid a possible missing dir there.
