### PR TITLE
Disable Jekyll auto mode when deploying web

### DIFF
--- a/deploy/config/deploy/web.rb
+++ b/deploy/config/deploy/web.rb
@@ -26,6 +26,6 @@ namespace :deploy do
   end
 
   task :jekyll_build do
-    run "cd #{deploy_to}/current && jekyll"
+    run "cd #{deploy_to}/current && jekyll --no-auto"
   end
 end


### PR DESCRIPTION
Deploy jobs are hanging on CI at the moment as the auto: true in the theforeman.org repo causes "jekyll" to stay running waiting for changes.
