### PR TITLE
Make Jenkins PostgreSQL role a superuser so it can disable FK constraints

### DIFF
--- a/puppet/modules/slave/manifests/postgresql.pp
+++ b/puppet/modules/slave/manifests/postgresql.pp
@@ -10,7 +10,7 @@ class slave::postgresql {
   # own databases when required
   postgresql::role { "foreman":
     password_hash => postgresql_password("foreman", "foreman"),
-    createdb      => true,
+    superuser     => true,
     login         => true,
     require       => Class["postgresql::server"],
   }


### PR DESCRIPTION
Needed to fix https://github.com/theforeman/foreman/pull/522, as during the test run we need to disable foreign key constraints to load fixtures, which can only be done by a superuser in PostgreSQL.  This doesn't affect dev/prod installs.
