### PR TITLE
Remove --recurse-submodules from redmine cron, add mailaliases

### DIFF
--- a/puppet/modules/redmine/manifests/config.pp
+++ b/puppet/modules/redmine/manifests/config.pp
@@ -124,4 +124,8 @@ class redmine::config {
   #  git_url => 'https://github.com/panicinc/redmine_vote.git'
   #}
 
+  mailalias { 'redmine':
+    ensure    => present,
+    recipient => 'sysadmins',
+  }
 }

--- a/puppet/modules/redmine/manifests/repo.pp
+++ b/puppet/modules/redmine/manifests/repo.pp
@@ -6,7 +6,7 @@ define redmine::repo(
   include git
 
   cron { "redmine-sync-cron-${name}":
-    command => "(cd ~/git/${name} && git pull --recurse-submodules && curl http://projects.theforeman.org/projects/${project_name}/repository ) > /dev/null",
+    command => "(cd ~/git/${name} && git pull -q && curl -sS http://projects.theforeman.org/projects/${project_name}/repository ) > /dev/null",
     user    => $redmine::user,
     minute  => string_to_cron($name,60),
   }

--- a/puppet/modules/utility/manifests/init.pp
+++ b/puppet/modules/utility/manifests/init.pp
@@ -1,4 +1,4 @@
-class utility {
+class utility($sysadmins = []) {
   include motd
 
   class { 'utility::repos': }
@@ -51,5 +51,14 @@ class utility {
   package { $puppet_packages:
     ensure => $puppet_version,
     require => Class['utility::repos'],
+  }
+
+  mailalias { 'sysadmins':
+    ensure    => present,
+    recipient => $sysadmins,
+  }
+  mailalias { 'root':
+    ensure    => present,
+    recipient => 'sysadmins',
   }
 }


### PR DESCRIPTION
It's not a valid option on EL6's git (as used on web).
