### PR TITLE
Add Foreman GPG Deb key to Pbuilder setup hook

### DIFF
--- a/puppet/modules/debian/templates/pbuilder_f70.erb
+++ b/puppet/modules/debian/templates/pbuilder_f70.erb
@@ -13,5 +13,43 @@
 echo "deb http://backports.debian.org/debian-backports/ <%= release %>-backports main" >> /etc/apt/sources.list
 
 <% end -%>
+
+# Get the Foreman GPG key, just in case we've added the repo
+# in an earlier hook (via Jenkins, say). Sadly wget is not available in
+# pbuilder image, so this is a bit hacky...
+cat <<EOF | apt-key add -
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+mQENBEzaPPkBCADZpJlUyz9PcekBFSu0MR/j+p2/M5zGBGraDHFh3C2S7xw3S/nc
+CI0lMj47Gb7Xa3dkoK1nEfMbbiB6B7PurjHxY8YcIvWEn8k1/DO9j4MMXqNBeU/j
+shb0KnrMyHDkHx+Yn5jJ5zsXXkuQiThrU7tW3tsEF62hfDceq9ERihQnySDkF/xn
+6rpv/UOaotCK35dglIPBHMwgtYvYAClcwsOk8QFKwJnFemvOz0oqQm1NM3F7B
+Ps0TlU6g6yDqTzeykeFFD9FFAV2LJYMd10h7yLIBeJQN/Gz899vzQIs9uBKv1gdv
+9Z39qH2nPoLf5h9FN08aJeHGFh3jiFsq1/BvABEBAAG0NUZvcmVtYW4gQXJjaGl2
+ZSBTaWduaW5nIEtleSA8cGFja2FnZXNAdGhlZm9yZW1hbi5vcmc+iQE4BBMBAgAi
+BQJM2jz5AhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRBmzwU/53X/B6jO
+B/0WpPnHLaWpP8EgUnpN7RPUX6nb9u+Snz+2NVaVDBvLAHxlohClXEo/2WrXIDYk
+Ijo5kTWo7X/wMtcbOeX6K7nh7cghIVo95DrOGEipyWJ1BBvnk2cS8pmGkHZzWSRA
+SiTgr14nLPWnKvBeho61Kl3jCsBcLve87mvJwzC76jr/4g+H0DF0GaUIAvRZXCXV
+NZIEVfT2HKj7RfOh9Qlcx+N6Yo4ovz7ChZMggot1qtJLVYah9fnByJgQ8k2YlwJI
+xfQiGj1kjXmAvpqBFGp13prQs7uDHXwD/kerzF4Z/nhVhXW4f0h4yeq1INC2GzXe
+pu3V4T8Tfojdbmm23/c2rrPeuQENBEzaPPkBCACq0agi4H2bPwKvx/H3PVKcLCMt
+RuY/OtTgdOm/600rqgVMzpXAFtTHMEatoXqWv6V61yVHjmHbLgUDEfV2Sjxw4/d+
+pU64AmKphpUvX4oArk2E3Dne4D2RVtO2XE6uPVjJ+GFjn9GTtbJoO/zqLW0dm3S6
+vQFOdFbX9XWr9B+wkdseq4F69KB1Nbiex/EN9QCnVKVCrfFE5grhSKSI9XZ0M5lM
+6OQddDQRMTxEs0A99r7mJFsWbL5x7ObMhXmBnOEWudyEA/biyxdP8jK9OJssqGJH
+sZKrzl9Tc+hgT73TR9Rds84CnKTbWTjycttMZdXXbVFRU2toz4WrxcF82gEPABEB
+AAGJAR8EGAECAAkFAkzaPPkCGwwACgkQZs8FP+d1/wdqYgf+IoiXzxlFVA+wQSZB
+nvvtwY8EuxjDHZ7Ab9gZeNiqW+Hz97mKCxNLbWJk49nC84DlfCkHl2Gm4z+r+phJ
+idONIZR4+fQV/cXrveAHjvHjmgiN+0tpdh4ZGhiyIZO17jGjwGGt+YfIIY43RKIb
+KLsP8E+yDO39HKeY1u3QCSqZ+r1dOvT+XgDE4ncfn55/YqKkY6ZeJAtj6iQxvJRG
+rlSod2yoZ9kySd3CxFU4ycpiFEKmq4HfVUMWcUVPqx8StvrfkZxGGds9qFmIgtwf
+K2hLSHJLKUex8Jh3TJuTgdMKFYVQ5bO7sY5ZnsXKxUvtgLmh2MZTU23IlNS/1aJg
+NL93tw==
+=LN8V
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+
 # Update apt
 /usr/bin/apt-get update


### PR DESCRIPTION
Have to add the GPG key directly as there's no curl or wget in the base pbuilder image. Nasty, but it's very unlikely to change....
