### PR TITLE
Multiuser Quassel module

### DIFF
--- a/puppet/modules/quassel/manifests/init.pp
+++ b/puppet/modules/quassel/manifests/init.pp
@@ -1,0 +1,55 @@
+class quassel (
+  $users = 'undef'
+) {
+
+  $db_password = cache_data('db_password', random_password(32))
+  $password    = postgresql_password('quasselcore', $db_password)
+
+  # Prevents errors if run from /root etc.
+  Postgresql_psql {
+    cwd => '/',
+  }
+
+  include postgresql::client, postgresql::server
+  postgresql::db { 'quassel':
+    user     => 'quasselcore',
+    password => $password,
+  }
+
+  package { 'quassel-core':
+    ensure => installed
+  }
+
+  service { 'quasselcore':
+    ensure => running
+  }
+
+  # User setup
+  file { '/var/cache/quassel':
+    ensure => directory,
+  }
+
+  file { '/usr/local/bin/quasselshell':
+    ensure  => present,
+    content => template('quassel/shell.erb'),
+    mode    => 0755,
+  }
+
+  include sudo
+  sudo::directive { "sudo-puppet-quassel":
+    ensure    => present,
+    content   => "%quassel ALL=NOPASSWD:/usr/bin/quasselcore *\n",
+  }
+
+  if $users == 'undef' {
+    # Create basic users, delete once foreman is updated
+    quassel::user{ 'gsutcliffe':
+      key => "AAAAB3NzaC1yc2EAAAADAQABAAABAQC+1sjrMV3VKV1zE5caeqE6rwU528I8bfNxbkYuWKyiR0n9jg2fWidCGdoWC6+KzMJqGqR/wO1m5VXj6lIKYyGbYm+f3SyI6B9NJ0h4P25fLcSGRCGwCvv3vkqehcDvir1bKwGU0BewrUwI5ljm4+nfAdhDO8hnrFKg8paRrbwRL7GeR/ZMCRMEFLsQT96z0NPUk5yDYWE3xCTcVKENP89OKc1Sk0J6Xk5FFDBrEExD/0cSe2WhblvVC7sL7k3YwLKbq36UxGTer1nCzY2v9AsUpI0hmqN4fwh1XDTPR6ONASRw1fazybrbFRnh/hmsm4X8EUAzbOClwXYBMixYwKmx"
+    }
+  } else {
+    # Users hash is passed from Foreman
+    create_resources(quassel::user, $users)
+  }
+
+
+}

--- a/puppet/modules/quassel/manifests/user.pp
+++ b/puppet/modules/quassel/manifests/user.pp
@@ -1,0 +1,31 @@
+define quassel::user(
+  $key
+) {
+
+  # This is a horrid hack, but there's no easy non-interactive way to add or check for users
+  exec { "add-${name}-to-quassel":
+    command => "/bin/echo -e \"${name}\nfoo\nfoo\" | /usr/bin/quasselcore --add-user --configdir=/var/lib/quassel && /bin/touch /var/cache/quassel/${user}/user-created",
+    creates => "/var/cache/quassel/${name}/user-created",
+  }
+
+  user { $name:
+    ensure => present,
+    shell  => '/usr/local/bin/quasselshell',
+    home   => "/var/cache/quassel/${name}",
+    groups => ['quassel'],
+  }
+
+  file { ["/var/cache/quassel/${name}","/var/cache/quassel/${name}/.ssh"]:
+    ensure => directory,
+    owner  => $name,
+    mode   => 0700,
+  }
+
+  file { "/var/cache/quassel/${name}/.ssh/authorized_keys":
+    ensure  => present,
+    owner   => $name,
+    mode    => 0600,
+    content => "ssh-rsa ${key} ${name}",
+  }
+
+}

--- a/puppet/modules/quassel/templates/shell.erb
+++ b/puppet/modules/quassel/templates/shell.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Welcome to Quassel"
+echo "------------------"
+
+echo "Changing Password for $USER"
+sudo /usr/bin/quasselcore --change-userpass=$USER --configdir=/var/lib/quassel
+
+echo "--------------------"
+echo "Goodbye from Quassel"


### PR DESCRIPTION
It has a nasty exec, but otherwise seems to function. Once merged, we can add a hash of users/keys to Foreman to create Quassel users, after which they can log in with their key to change their password.

@domcleal has tested it briefly, seems fairly proof. Users should only be able to alter their own password, and not break out into a shell.
