### PR TITLE
Add Ruby code highlighting plugin

### DIFF
--- a/puppet/modules/redmine/manifests/config.pp
+++ b/puppet/modules/redmine/manifests/config.pp
@@ -140,6 +140,10 @@ class redmine::config {
     git_url => 'https://github.com/backlogs/redmine_backlogs.git'
   }
 
+  plugin{'redmine_ruby_code':
+    git_url => 'https://github.com/ares/redmine_ruby_code.git'
+  }
+
   mailalias { 'redmine':
     ensure    => present,
     recipient => 'sysadmins',


### PR DESCRIPTION
This will add ruby icon to every toolbar above textarea so you can easily wrap a code into a block which will be printed using ruby highlighting. Small but useful I'd say.
