### PR TITLE
New module foreman_debug_sync

### DIFF
--- a/puppet/modules/foreman_debug_rsync/Modulefile
+++ b/puppet/modules/foreman_debug_rsync/Modulefile
@@ -1,0 +1,12 @@
+name    'lzap/foreman_debug_rsync'
+version '0.1.0'
+source 'UNKNOWN'
+author 'lzap'
+license 'Apache License, Version 2.0'
+summary 'Configures rsync to accept foreman-debug tarballs'
+description 'Configures rsync to accept foreman-debug tarballs'
+project_page 'UNKNOWN'
+
+dependency 'puppetlabs/stdlib', '>= 4.1.0'
+dependency 'puppetlabs/rsync', '>= 0.1.0'
+dependency 'puppetlabs/xinetd', '>= 1.2.0'

--- a/puppet/modules/foreman_debug_rsync/README
+++ b/puppet/modules/foreman_debug_rsync/README
@@ -1,0 +1,3 @@
+This is the foreman_debug_rsync module.
+
+Configures rsync to accept foreman-debug tarballs.

--- a/puppet/modules/foreman_debug_rsync/manifests/config.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/config.pp
@@ -1,0 +1,25 @@
+class foreman_debug_rsync::config {
+
+  include 'rsync'
+  include 'rsync::server'
+
+  file { $foreman_debug_rsync::base:
+    ensure => directory,
+    mode   => 770,
+    owner  => 'nobody',
+    group  => 'nobody',
+  }
+
+  rsync::server::module{ 'debug-incoming':
+    path            => $foreman_debug_rsync::base,
+    require         => File[$foreman_debug_rsync::base],
+    comment         => 'Write-only place for foreman-debug',
+    max_connections => 15,
+    read_only       => 'no',
+    write_only      => 'yes',
+    list            => 'no',
+    uid             => 'nobody',
+    gid             => 'nobody',
+  }
+
+}

--- a/puppet/modules/foreman_debug_rsync/manifests/cron.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/cron.pp
@@ -1,0 +1,8 @@
+class foreman_debug_rsync::cron {
+  cron { 'remove-old-tarballs':
+    command => "/usr/bin/find $foreman_debug_rsync::base -type f -mtime +90 -exec rm {} \\;",
+    user    => 'nobody',
+    hour    => 3,
+    minute  => 0
+  }
+}

--- a/puppet/modules/foreman_debug_rsync/manifests/init.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/init.pp
@@ -1,0 +1,8 @@
+class foreman_debug_rsync (
+  $base = '/home/foreman-debug-rsync',
+) {
+
+  class { 'foreman_debug_rsync::config': } ->
+  class { 'foreman_debug_rsync::cron': }
+
+}


### PR DESCRIPTION
This adds write-only rsync target that is available to public for uploading
tarballs from foreman-debug. I plan to integrate this into the script.

Currently it points to `/home` volume, but I am able to change this default to
anything else.
