### PR TITLE
foreman-debug - changing permissions for all to list directory

### DIFF
--- a/puppet/modules/foreman_debug_rsync/manifests/config.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/config.pp
@@ -5,7 +5,7 @@ class foreman_debug_rsync::config {
 
   file { $foreman_debug_rsync::base:
     ensure => directory,
-    mode   => 770,
+    mode   => 775,
     owner  => 'nobody',
     group  => 'nobody',
   }


### PR DESCRIPTION
Otherwise only root could list the contents of incoming foreman-debug reports.
