### PR TITLE
Updating installed Bower version to fix intermitent 'lstat' and 'rename'...

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -115,7 +115,7 @@ class slave($github_user = undef,
     } -> Package <| provider == 'npm' |>
 
     package { 'bower':
-      ensure   => '1.3.1',
+      ensure   => '1.3.3',
       provider => npm,
     }
     package { ['phantomjs', 'grunt-cli']:


### PR DESCRIPTION
... issues.

Katello test runs have suddenly been getting errors and I was also getting them locally. Updating locally to this version fixed my issues so I'd like to update the slaves with this new version as well.
