### PR TITLE
Add downloads.theforeman.org vhost

### DIFF
--- a/puppet/modules/web/files/downloads-HEADER.html
+++ b/puppet/modules/web/files/downloads-HEADER.html
@@ -1,0 +1,17 @@
+<title>downloads.theforeman.org</title>
+<head><h1>downloads.theforeman.org</h1></head>
+<body>
+
+<h3>Official downloads</h3>
+
+<p>Official tarballs of core Foreman projects are made available here for download and repackaging.</p>
+
+<p>Packages of our projects are also available at <a href="http://deb.theforeman.org">deb.theforeman.org</a> and <a href="http://yum.theforeman.org">yum.theforeman.org</a>, while gems are published to <a href="http://rubygems.org">rubygems.org</a>.</p>
+
+<h3>Support</h3>
+
+<p>You can find installation instructions <a href="http://theforeman.org/manuals/latest/index.html#3.3InstallFromPackages">here</a>, but we strongly recommend using our <a href="http://theforeman.org/manuals/latest/index.html#3.2ForemanInstaller">Installer</a>.
+
+<p>If you have any issues, you can find the mailing list on <a href="https://groups.google.com/forum/?fromgroups#!forum/foreman-users">Google Groups</a> or on IRC (Freenode, #theforeman)</p>
+<br/>
+</body>

--- a/puppet/modules/web/files/downloads.theforeman.org.conf
+++ b/puppet/modules/web/files/downloads.theforeman.org.conf
@@ -1,0 +1,16 @@
+<VirtualHost *:80>
+  DocumentRoot         /var/www/vhosts/downloads/htdocs
+  ServerName           downloads.theforeman.org
+
+  <Directory /var/www/vhosts/downloads/htdocs>
+    Options Indexes FollowSymLinks
+  </Directory>
+
+  LogLevel warn
+  ServerSignature Off
+
+  ErrorLog /var/log/httpd/error_log
+  LogLevel warn
+  CustomLog /var/log/httpd/access_log combined
+  ServerSignature Off
+</VirtualHost>

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -51,4 +51,22 @@ class web($latest = "1.4") {
     ensure => link,
     target => $latest,
   }
+
+  apache::vhost { "downloads":
+    ensure => present,
+    config_file => "puppet:///modules/web/downloads.theforeman.org.conf"
+  }
+  rsync::server::module { 'downloads':
+    path      => '/var/www/vhosts/downloads/htdocs',
+    list      => true,
+    read_only => true,
+    comment   => 'downloads.theforeman.org',
+  }
+  file { '/var/www/vhosts/downloads/htdocs/HEADER.html':
+    ensure => present,
+    owner  => 'root',
+    group  => 'root',
+    mode   => 0644,
+    source => 'puppet:///modules/web/downloads-HEADER.html',
+  }
 }


### PR DESCRIPTION
This will be a new location for tarballs (which we can pull into packages) to replace redmine (http://projects.theforeman.org/projects/foreman/files) which has unpredictable URLs and is harder to upload files to automatically.

It can also serve as a better place for discovery images instead of using {deb,yum}.tf.org.

@ohadlevy would you mind adding this to DNS please?
