### PR TITLE
Gzip the db dump for easier remote backup

### DIFF
--- a/puppet/modules/redmine/manifests/cron.pp
+++ b/puppet/modules/redmine/manifests/cron.pp
@@ -4,7 +4,7 @@ class redmine::cron {
 
   # Backups
   cron { 'redmine-backup':
-    command => "(cd ${redmine::local_dir} && pg_dump ${redmine::db_name} > db/production.psqldump)",
+    command => "(cd ${redmine::local_dir} && pg_dump ${redmine::db_name} > db/production.psqldump && gzip -9 db/production.psqldump)",
     user    => $redmine::user,
     minute  => string_to_cron('redmine-backup'),
     hour    => string_to_cron('redmine-backup-hour', '24'),


### PR DESCRIPTION
I'll be adding the db backups to the dirvish set so we have more than one day of backups, but a gzipped file is easier to rsync... especially when it goes 45mb -> 9mb...
