### PR TITLE
Switch freight source to domcleal-freight copr

### DIFF
--- a/puppet/modules/freight/manifests/install.pp
+++ b/puppet/modules/freight/manifests/install.pp
@@ -13,12 +13,15 @@ class freight::install {
       ensure  => installed,
     }
   } else {
+    yumrepo { 'freight':
+      descr    => 'Freight',
+      baseurl  => 'http://copr-be.cloud.fedoraproject.org/results/domcleal/freight/epel-6-$basearch/',
+      gpgcheck => '0',
+      enabled  => '1',
+    } ->
     package { 'freight':
-      provider => 'rpm',
-      ensure   => installed,
-      source   => "http://skottler.fedorapeople.org/packages/freight-0.3.2-1.x86_64.rpm",
+      ensure => 'latest',
     }
-    package { 'dpkg': ensure => installed }
   }
 
 }


### PR DESCRIPTION
<pre>
[root@foreman ~]# puppet apply test.pp
notice: /Stage[main]//Yumrepo[freight]/descr: descr changed '' to 'Freight'
notice: /Stage[main]//Yumrepo[freight]/baseurl: baseurl changed '' to 'http://copr-be.cloud.fedoraproject.org/results/domcleal/freight/epel-6-$basearch/'
notice: /Stage[main]//Yumrepo[freight]/enabled: enabled changed '' to '1'
notice: /Stage[main]//Yumrepo[freight]/gpgcheck: gpgcheck changed '' to '0'
notice: /Stage[main]//Package[freight]/ensure: created
notice: Finished catalog run in 12.58 seconds
[root@foreman ~]# rpm -q freight
freight-0.3.5-1.el6.noarch
[root@foreman ~]# freight add
Usage: freight add [-c <conf>] [-v] [-h] <package> <manager>/<distro>...
  -c <conf>, --conf=<conf> config file to parse
  -v, --verbose            verbose mode
  -h, --help               show this help message
</pre>
