### PR TITLE
Allow rsync-based deployments to web nodes

### DIFF
--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -1,5 +1,6 @@
 class web($latest = "1.5") {
   include rsync::server
+  include web::website_user
 
   file { "/etc/httpd/conf.d/welcome.conf":
     ensure => absent

--- a/puppet/modules/web/manifests/uploader.pp
+++ b/puppet/modules/web/manifests/uploader.pp
@@ -1,0 +1,29 @@
+# Cheap class to deploy an SSH private key for use in contacting the web server
+# to upload the compiled static site
+#
+class web::uploader {
+
+  $pub_key  = ssh_keygen({name => 'web_key', public => 'public'})
+  $priv_key = ssh_keygen({name => 'web_key'})
+
+  file { '/var/lib/workspace/workspace':
+    ensure => directory,
+    owner  => 'jenkins',
+    group  => 'jenkins',
+    mode   => 0664,
+  }
+
+  file { '/var/lib/workspace/workspace/ssh_key_web':
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    mode    => 0400,
+    content => "${priv_key}",
+  }
+
+  file { '/var/lib/workspace/workspace/ssh_key_web.pub':
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    mode    => 0644,
+    content => "ssh-rsa ${pub_key} puppet_web_key\n",
+  }
+}

--- a/puppet/modules/web/manifests/website_user.pp
+++ b/puppet/modules/web/manifests/website_user.pp
@@ -1,0 +1,58 @@
+class web::website_user {
+
+  # Disable password, we want this to be keys only
+  user { 'website':
+    ensure     => present,
+    home       => '/home/website',
+    managehome => true,
+    password   => '!',
+  }
+  ->
+  file { '/home/website/.ssh':
+    ensure => directory,
+    owner  => 'website',
+    group  => 'website',
+    mode   => 0700,
+  }
+  ->
+  file { '/home/website/rsync_cache':
+    ensure => directory,
+    owner  => 'website',
+    group  => 'website',
+  }
+
+  # Read the web key from the puppetmaster
+  $pub_key  = ssh_keygen({name => 'web_key', public => 'public'})
+
+  # Get the IPs of the Web Builder slaves from foreman
+  $ip_data=foreman({
+    'item'         => 'fact_values',
+    'search'       => 'host = slave01.rackspace.theforeman.org and name = ipaddress',
+    'foreman_user' => $::foreman_api_user,
+    'foreman_pass' => $::foreman_api_password,
+    })
+
+  file { '/home/website/.ssh/authorized_keys':
+    ensure  => present,
+    owner   => 'website',
+    group   => 'website',
+    mode    => 0644,
+    content => template('web/keys.erb'),
+  }
+
+  # Create validation script for rsync connections only
+  file { '/home/website/bin':
+    ensure => directory,
+    owner   => 'website',
+    group   => 'website',
+    mode   => 0755,
+  }
+
+  file { '/home/website/bin/web_rsync':
+    ensure  => present,
+    owner   => 'website',
+    group   => 'website',
+    mode    => 0755,
+    content => template('web/rsync.erb'),
+  }
+}

--- a/puppet/modules/web/templates/keys.erb
+++ b/puppet/modules/web/templates/keys.erb
@@ -1,0 +1,3 @@
+<% @ip_data.sort.each do |host,data| -%>
+from="<%= data['ipaddress'] %>",command="/home/website/bin/web_rsync" ssh-rsa <%= @pub_key %> <%= host %>
+<% end -%>

--- a/puppet/modules/web/templates/rsync.erb
+++ b/puppet/modules/web/templates/rsync.erb
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+case "$SSH_ORIGINAL_COMMAND" in
+*\&*)
+echo "Rejected"
+;;
+*\(*)
+echo "Rejected"
+;;
+*\{*)
+echo "Rejected"
+;;
+*\;*)
+echo "Rejected"
+;;
+*\<*)
+echo "Rejected"
+;;
+*\`*)
+echo "Rejected"
+;;
+*\|*)
+echo "Rejected"
+;;
+rsync\ --server*)
+# Only push to the rsync cache
+if [[ `echo $SSH_ORIGINAL_COMMAND | awk '{ print $NF }'` =~ ^rsync_cache/.* ]] ; then
+  # Permit transfer
+  $SSH_ORIGINAL_COMMAND
+
+  find /home/website/rsync_cache -type f -exec chmod 644 {} \;
+  find /home/website/rsync_cache -type d -exec chmod 755 {} \;
+  # Publish the site
+  rsync -avPx /home/website/rsync_cache/ /var/www/vhosts/web_theforeman.org/ --delete-after
+  # Cleanup - no need to keep the tmp site
+  rm -rf /home/website/rsync_cache/*
+fi
+exit 0
+;;
+*)
+echo "Rejected"
+;;
+esac
+# ERB highlighting looks terrible in this script...
+# vim: set ft=sh : #


### PR DESCRIPTION
See also http://ci.theforeman.org/job/deploy_web_nocap/6/console for an example of it running

Lots of hardcoding here, but we're already hardcoding the site dir anyway, so it's fine. Feels like we can probably extra the rsync stuff into a module/define of it's own at some point - it's _very_ similar to the freight stuff...
