### PR TITLE
Add basic inbound/outbound firewall, and a customised one for web hosts

### DIFF
--- a/puppet/modules/rbot/templates/redmine_urls.rb.erb
+++ b/puppet/modules/rbot/templates/redmine_urls.rb.erb
@@ -155,11 +155,11 @@ class RedmineUrlsPlugin < Plugin
   # if the channel isn't in the channelmap.
   #
   def base_url(target)
-    "http://theforeman.org"
+    "http://projects.theforeman.org"
   end
 
   def rev_url(base_url, project, num)
-    base_url + '/repositories/revision/' + project + '/' + num
+    base_url + '/projects/' + project + '/repository/revisions/' + num
   end
 
   def pr_url(proj, num, org = "theforeman")

--- a/puppet/modules/web/templates/web.conf.erb
+++ b/puppet/modules/web/templates/web.conf.erb
@@ -5,7 +5,6 @@
 
   DocumentRoot /var/www/vhosts/web/htdocs
   RewriteEngine on
-  RewriteRule   ^/projects(.*)  http://projects.theforeman.org/projects$1  [R,L]
   RewriteRule   ^/issues(.*)  http://projects.theforeman.org/issues$1  [R,L]
   RewriteRule   ^/versions(.*)  http://projects.theforeman.org/versions$1  [R,L]
   RewriteRule   ^/wiki(.*)  http://projects.theforeman.org/wiki$1  [R,L]


### PR DESCRIPTION
New firewall, for review. Don't apply this to hosts yet :)

Current setup:

default DENY in and out
DNS & NTP allowed NEW outbound
SSH allowed NEW/ESTABLISHED inbound
SSH allowed ESTABLISHED only oubound
Puppet(8140) allowed NEW outbound

The web class adds https/rsync ports for yum and rsyncd

We can extend this further to the other hosts as time allows for testing what ports are required (eg I can imagine ci.theforeman.org will need outbound SSH state:NEW for Jenkins)

Thoughts?