### PR TITLE
pkg qpid-client-cpp-devel to RedHat only slaves.

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -124,6 +124,21 @@ class slave($github_user = undef,
     }
   }
 
+  # needed by katello gem dependency qpid-messaging
+  # to interface with candlepin's event topic
+  if $osfamily == 'RedHat' {
+    yumrepo { 'katello-pulp':
+      descr    => "Katello Pulp Repo",
+      baseurl  => "http://fedorapeople.org/groups/katello/releases/yum/katello-pulp/RHEL/\$releasever/\$basearch",
+      gpgcheck => '1',
+      gpgkey   => 'http://www.katello.org/gpg/RPM-GPG-KEY-katello-2012.gpg',
+      enabled  => '1',
+    } ~>
+    package { 'qpid-client-cpp-devel':
+      ensure => present;
+    }
+  }
+
   # specs-from-koji
   if $osfamily == 'RedHat' {
     package {


### PR DESCRIPTION
Add package qpid-client-cpp-devel to RedHat only slaves. It's needed by
Katello's gem dependency, qpid_messaging.
