### PR TITLE
Exporting debugs via apache2

### DIFF
--- a/puppet/modules/foreman_debug_rsync/manifests/init.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/init.pp
@@ -1,5 +1,5 @@
 class foreman_debug_rsync (
-  $base = '/home/foreman-debug-rsync',
+  $base = '/var/www/vhosts/debugs/htdocs',
 ) {
 
   class { 'foreman_debug_rsync::config': } ->

--- a/puppet/modules/web/manifests/htpasswd.pp
+++ b/puppet/modules/web/manifests/htpasswd.pp
@@ -1,0 +1,12 @@
+define web::htpasswd(
+  $vhost,
+  $passwd = undef
+) {
+  apache::auth::htpasswd {"${name} in ${vhost}":
+    ensure           => present,
+    userFileLocation => "/var/www/vhosts/${vhost}",
+    userFileName     => "htpasswd",
+    username         => $name,
+    clearPassword    => $passwd,
+  }
+}

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -1,4 +1,4 @@
-class web($latest = "1.5") {
+class web($latest = "1.5", $htpasswds = {}) {
   include rsync::server
 
   secure_rsync::receiver_setup { 'web':
@@ -19,11 +19,24 @@ class web($latest = "1.5") {
     mode           => 0755,
   }
 
+  apache::vhost { "debugs":
+    ensure         => present,
+    config_content => template("web/debugs.conf.erb"),
+    user           => 'nobody',
+    group          => 'nobody',
+    mode           => 0755,
+  }
+
   apache::vhost { "yum":
     ensure      => present,
     config_file => "puppet:///modules/web/yum.theforeman.org.conf",
     mode        => 2575,
   }
+
+  # Auths
+  # takes a hash like: { 'user' => { 'vhost' => 'debugs', passwd => 'secret' }
+  create_resources(web::htpasswd, $htpasswds)
+
   rsync::server::module { 'yum':
     path      => '/var/www/vhosts/yum/htdocs',
     list      => true,

--- a/puppet/modules/web/templates/debugs.conf.erb
+++ b/puppet/modules/web/templates/debugs.conf.erb
@@ -1,0 +1,17 @@
+# file managed by puppet
+<VirtualHost *:80>
+  ServerName debugs.theforeman.org
+
+  DocumentRoot /var/www/vhosts/debugs/htdocs
+
+  AuthType Digest
+  AuthName "Foreman-debug uploads - restricted area"
+  AuthBasicProvider file
+  AuthUserFile /var/www/vhosts/debugs/htpasswd
+  Require valid-user
+
+  ErrorLog /var/log/httpd/debugs_error_log
+  LogLevel warn
+  CustomLog /var/log/httpd/debugs_access_log combined
+  ServerSignature Off
+</VirtualHost>


### PR DESCRIPTION
This adds two parameters username/password to web and exports the tarballs
collected by rsync via apache2 httpd. I will go head and move them from
`/home/foreman-debug` to the new location `/var/www/vhosts/debugs/htdocs`
