### PR TITLE
Add infra-deploy-via-ssh mechanism module

### DIFF
--- a/puppet/modules/deploy/manifests/init.pp
+++ b/puppet/modules/deploy/manifests/init.pp
@@ -1,0 +1,54 @@
+class deploy {
+  # Adapted from secure_rsync for a pure ssh solution
+  $user           = 'deploypuppet'
+  $homedir        = '/home/deploypuppet'
+  $foreman_search = 'host.name = slave01.rackspace.theforeman.org and name = ipaddress'
+
+  # Disable password, we want this to be keys only
+  user { $user:
+    ensure     => present,
+    home       => $homedir,
+    managehome => true,
+    password   => '!',
+  }
+  ->
+  file { "${homedir}/.ssh":
+    ensure => directory,
+    owner  => $user,
+    mode   => '0700',
+  }
+
+  # Read the web key from the puppetmaster
+  $pub_key  = ssh_keygen({name => 'deploy_key', public => 'public'})
+
+  if $foreman_search {
+    # Get the IPs of the admin slave from foreman
+    $ip_data=foreman({
+      'item'         => 'fact_values',
+      'search'       => $foreman_search,
+      'foreman_user' => $::foreman_api_user,
+      'foreman_pass' => $::foreman_api_password,
+      })
+  }
+
+  file { "${homedir}/.ssh/authorized_keys":
+    ensure  => present,
+    owner   => $user,
+    mode    => '0700',
+    content => template('deploy/auth_keys.erb'),
+  }
+
+  # Create validation script for rsync connections only
+  file { "${homedir}/bin":
+    ensure => directory,
+    owner  => $user,
+    mode   => '0700',
+  }
+
+  file { "${homedir}/bin/deploy_puppet":
+    ensure  => present,
+    owner   => $user,
+    mode    => '0700',
+    content => template('deploy/script.erb'),
+  }
+}

--- a/puppet/modules/deploy/manifests/slave.pp
+++ b/puppet/modules/deploy/manifests/slave.pp
@@ -1,0 +1,26 @@
+class deploy::slave {
+  # Adapted from secure_rsync for a pure ssh solution
+  $user = 'jenkins'
+  $dir  = '/var/lib/workspace/workspace/deploy_key'
+
+  $pub_key  = ssh_keygen({name => 'deploy_key', public => 'public'})
+  $priv_key = ssh_keygen({name => 'deploy_key'})
+
+  file { $dir:
+    ensure => directory,
+    owner  => $user,
+    mode   => '0700',
+  }
+
+  file { "${dir}/deploy_key":
+    owner   => $user,
+    mode    => '0400',
+    content => $priv_key,
+  }
+
+  file { "${dir}/deploy_key.pub":
+    owner   => $user,
+    mode    => '0644',
+    content => "ssh-rsa ${pub_key} deploy_key from puppetmaster\n",
+  }
+}

--- a/puppet/modules/deploy/templates/auth_keys.erb
+++ b/puppet/modules/deploy/templates/auth_keys.erb
@@ -1,0 +1,12 @@
+<%
+  if @ip_data.nil?
+    # Flat array from user
+    array = @allowed_ips
+  else
+    # Facts hash from Foreman
+    array = @ip_data.values.map{|a| a['ipaddress']}
+  end
+-%>
+<% array.each do |ip| -%>
+from="<%= ip %>",command="<%= @homedir %>/bin/deploy_puppet" ssh-rsa <%= @pub_key %> <%= ip %>_deploy_puppet
+<% end -%>

--- a/puppet/modules/deploy/templates/script.erb
+++ b/puppet/modules/deploy/templates/script.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e # dont rsync if clone fails
+echo "Deploy started at `date`"
+dir=`mktemp -d`
+trap "rm -rf $dir" EXIT
+git clone --recursive https://github.com/theforeman/foreman-infra $dir/
+rsync -aqx --delete-after --exclude=.git $dir/puppet/modules/ /etc/puppet/environments/production/modules/
+echo "Deploy complete at `date`"
+# ERB highlighting looks terrible in this script...
+# vim: set ft=sh : #


### PR DESCRIPTION
Once this manifest is in place, a slave with the deploy::slave class can do something like

```
ssh deploypuppet@208.74.145.200 -i /var/lib/workspace/workspace/deploy_key/deploy_key
```

Which will trigger the git-clone/rsync on the master. The `command=...` parameter in authorized keys replaces whatever the slave specifies as a command, so in the event of a slave being compromised, the attacker cannot use this key to execute anything else.
