### PR TITLE
Add key to deploy Katello repos on fedorapeople.

### DIFF
--- a/puppet/modules/deploy/manifests/slave.pp
+++ b/puppet/modules/deploy/manifests/slave.pp
@@ -3,4 +3,9 @@ class deploy::slave {
     user => 'jenkins',
     dir  => '/var/lib/workspace/workspace/deploy_key',
   }
+
+  secure_ssh::uploader_key { 'deploy_katello_repos':
+    user => 'jenkins',
+    dir  => '/var/lib/workspace/workspace/deploy_katello_repos_key',
+  }
 }


### PR DESCRIPTION
This key is to be solely used to ssh into fedorapeople and run the
rsync script within the Katello group to sync repos off of Koji
initiated by a Jenkins job.
