### PR TITLE
Prevent yum's repomd.xml from being cached by proxies

### DIFF
--- a/puppet/modules/web/files/yum.theforeman.org.conf
+++ b/puppet/modules/web/files/yum.theforeman.org.conf
@@ -10,8 +10,15 @@
       RewriteEngine On
       RewriteRule (.*)/fc(\d+)/(.*) $1/f$2/$3
     </IfModule>
-
   </Directory>
+
+  # Prevent top-level repodata file being cached
+  <IfModule mod_expires.c>
+    <File "repomd.xml">
+      ExpiresActive on
+      ExpiresDefault "access plus 0 seconds"
+    </File>
+  </IfModule>
 
   LogLevel warn
   ServerSignature Off

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -27,6 +27,10 @@ class web($latest = "1.6", $htpasswds = {}) {
     mode           => 0755,
   }
 
+  apache::module { "expires":
+    ensure => present,
+    notify => Exec["apache-graceful"],
+  }
   apache::vhost { "yum":
     ensure      => present,
     config_file => "puppet:///modules/web/yum.theforeman.org.conf",


### PR DESCRIPTION
repomd.xml is always present and links to uniquely named files each time we
generate repos, so when transparent proxies cache it, but not the other files
then the repodata is out of sync for clients.

Disable all caching of repomd.xml alone so clients should see immediately when
the repo changes without affecting caching of other files.  (No explicit cache
controls headers are added by default.)
