### PR TITLE
adding QT to jenkins server

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -114,6 +114,12 @@ class slave($github_user = undef,
       name => $osfamily ? {
         Debian => "libaugeas-dev",
         default => "augeas-devel"
+      };
+    "lib-qt":
+      ensure => present,
+      name => $osfamily ? {
+        Debian => "libqt4-dev",
+        default => "libqt4-devel"
       }
   }
 


### PR DESCRIPTION
in order to run a headless browser, we need libQT on the CI.