### PR TITLE
Initial setup/use of jenkins-job-builder

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/config/scripts/debian/configure_pbuilder.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/debian/configure_pbuilder.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -xe
+
+git checkout origin/deb/${repo} -b local || git checkout ${repo} -b local
+
+# This script sets up the PBuilder hooks to pull in our deb repositories while the package is building
+echo "--Apt Hook Setup"
+
+# Cleanup any old hooks
+sudo rm -f /etc/pbuilder/${os}64/hooks/F60addforemanrepo
+sudo rm -f /etc/pbuilder/${os}32/hooks/F60addforemanrepo
+
+if wget -O/dev/null -q http://stagingdeb.theforeman.org/dists/${os}/${repoowner}-${version} ; then
+  echo "echo deb http://stagingdeb.theforeman.org/ ${os} ${repoowner}-${version} >> /etc/apt/sources.list" | sudo tee -a /etc/pbuilder/${os}64/hooks/F60addforemanrepo > /dev/null
+  echo "echo deb http://stagingdeb.theforeman.org/ ${os} ${repoowner}-${version} >> /etc/apt/sources.list" | sudo tee -a /etc/pbuilder/${os}32/hooks/F60addforemanrepo > /dev/null
+fi
+
+# Use tee to get around sudo/redirection problems, with /dev/null to drop the stdout
+echo "echo deb http://deb.theforeman.org/ ${os} ${version} >> /etc/apt/sources.list" | sudo tee -a /etc/pbuilder/${os}64/hooks/F60addforemanrepo > /dev/null
+echo "echo deb http://deb.theforeman.org/ ${os} ${version} >> /etc/apt/sources.list" | sudo tee -a /etc/pbuilder/${os}32/hooks/F60addforemanrepo > /dev/null
+
+# Permit per-OS/project setups to add their own repos
+if [ -e debian/${os}/${project}/hooks ]; then
+  sed "s/%OS%/${os}/g" debian/${os}/${project}/hooks | sudo tee -a /etc/pbuilder/${os}32/hooks/F60addforemanrepo
+  sed "s/%OS%/${os}/g" debian/${os}/${project}/hooks | sudo tee -a /etc/pbuilder/${os}64/hooks/F60addforemanrepo
+fi
+
+# Make executable
+sudo chmod 0775 /etc/pbuilder/${os}64/hooks/F60addforemanrepo
+sudo chmod 0775 /etc/pbuilder/${os}32/hooks/F60addforemanrepo

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/debian/deploy_deb.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/debian/deploy_deb.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+
+ssh -i /var/lib/workspace/workspace/deb_key/rsync_freight_key freight@deb.theforeman.org deploy ${os} ${repo}

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/debian/execute_pbuilder.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/debian/execute_pbuilder.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -xe
+
+# This script clones the git repos, cleans them up, and builds the package
+echo "--Setting Up Sources"
+
+# Setup the debian files, figure out the version
+echo `git log -n1 --oneline`
+cd debian/${os}/
+VERSION=$(head -n1 ${project}/changelog|awk '{print $2}'|sed 's/(//;s/)//'|cut -f1 -d-)
+
+# Setup sources 
+mkdir build-${project} && cd build-${project}
+if [[ x$repo =~ ^xdevelop ]]; then
+  url_base='http://ci.theforeman.org'
+  job_name=$nightly_jenkins_job  # e.g. 'test_develop', from triggering job
+  job_id=$nightly_jenkins_job_id # e.g. '123', from triggering
+  json_url="${url_base}/job/${job_name}/${job_id}/api/json"
+
+  # If a last* alias was used, resolve the numeric job ID
+  job_id=$(curl "${json_url}" | /usr/local/bin/JSON.sh -b | awk '$1 == "[\"number\"]" { print $2 }')
+  base_url=`curl "${json_url}" | /usr/local/bin/JSON.sh -b | awk '$1 ~ /^\["runs",.*,"number"\]/ && $2 == '$job_id' {getline; print $2; exit}' | tr -d \"`
+  if [ x$base_url = x ] ; then
+    base_url=`curl "${json_url}" | /usr/local/bin/JSON.sh -b | egrep '\["url"\]' | awk '{print $NF}' | tr -d \"`
+  fi
+  url="${base_url}/artifact/*zip*/archive.zip" 
+  
+  wget $url
+  unzip archive.zip
+  mv archive/pkg/*bz2 ${project}_${VERSION}.orig.tar.bz2
+  
+  # Set this in case we need it 
+  LAST_COMMIT=`curl "${json_url}" | /usr/local/bin/JSON.sh -b | egrep '"lastBuiltRevision","SHA1"' | awk '{print $NF}' | tr -d \"`
+else
+  VERSION=`echo ${VERSION} | tr '~rc' '-RC'`
+  # Download sources
+  wget http://downloads.theforeman.org/${project}/${project}-${VERSION}.tar.bz2
+  wget http://downloads.theforeman.org/${project}/${project}-${VERSION}.tar.bz2.sig
+
+  # Verify with packaging key - commented until we can handle multiple keys
+#  tmp_keyring="./1AA043B8-keyring.gpg"
+#  gpg --no-default-keyring --keyserver keys.gnupg.net --keyring $tmp_keyring --recv-keys 1AA043B8
+#  if gpg --no-default-keyring --keyring $tmp_keyring ${project}-${VERSION}.tar.bz2.sig 2>&1 | grep -q "gpg: Good signature from \"Foreman Automatic Signing Key (2014) <packages@theforeman.org>\"" ; then
+#    true # ok
+#  else
+#    exit 2
+#  fi
+  mv ${project}-${VERSION}.tar.bz2 ${project}_${VERSION}.orig.tar.bz2
+
+  # Set this for test builds
+  LAST_COMMIT=${VERSION}
+fi
+
+# Unpack
+tar xvjf ${project}_${VERSION}.orig.tar.bz2
+
+# Bring in the debian packaging files
+cp -r ../${project} ./${project}-${VERSION}/debian
+cd ${project}-${VERSION}
+
+# Add changelog entry if this is a git/nightly build
+if [ x$gitrelease = xtrue ] || [ x$pr_number != x ]; then
+  PACKAGE_NAME=$(head -n1 debian/changelog|awk '{print $1}')
+  DATE=$(date -R)
+  UNIXTIME=$(date +%Y%m%d%H%M )
+  RELEASE="9999-${os}+scratchbuild+${UNIXTIME}"
+  MAINTAINER="${repoowner} <no-reply@theforeman.org>"
+  mv debian/changelog debian/changelog.tmp
+  echo "$PACKAGE_NAME ($RELEASE) UNRELEASED; urgency=low
+
+  * Automatically built package based on the state of
+    foreman-packaging at commit $LAST_COMMIT
+
+ -- $MAINTAINER  $DATE
+" > debian/changelog
+
+  cat debian/changelog.tmp >> debian/changelog
+  rm -f debian/changelog.tmp
+  
+  # rename orig tarball to stop lintian complaining
+  mv ../${project}_${VERSION}.orig.tar.bz2 ../${project}_9999.orig.tar.bz2
+fi
+
+# Build the package for the OS using pbuilder
+# needs sudo as pedebuild uses loop and bind mounts
+# TODO: handle 32bit stuff here
+sudo pdebuild-${os}64
+# Only foreman is binary-dependant
+if [ x$project = xforeman ]; then
+  sudo pdebuild-${os}32
+fi
+
+# Cleanup, pdebuild uses root
+sudo chown -R jenkins:jenkins $WORKSPACE

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/debian/stage_packages.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/debian/stage_packages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -xe
+
+# Script to copy the newly-built debs to the web node for signing and promoting
+# Dependencies
+# * the freight::client class in foreman-infra
+# * the web node must have the freight class applied
+
+# Find the deps in the build-dir from the previous step
+DEB_PATH=./debian/${os}/build-${project}
+
+# Upload all builds to stagingdeb for testing
+echo "scratch build: uploading to stagingdeb/${os}/${repoowner}-${version}"
+export RSYNC_RSH="ssh -i /var/lib/workspace/workspace/staging_key/rsync_freightstage_key"
+USER=freightstage
+HOST=stagingdeb
+COMPONENT=${repoowner}-${version}
+
+# The path is important, as freight_rsync (which is run on the web node for incoming
+# transfers) will parse the path to figure out the repo to send debs to.
+TARGET_PATH="${USER}@${HOST}.theforeman.org:rsync_cache/${os}/${COMPONENT}/"
+
+/usr/bin/rsync -avPx $DEB_PATH/*deb $TARGET_PATH

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/deploy_web.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/deploy_web.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -xe
+
+# Build the site on the slave 
+
+ruby=2.0.0
+# RVM Ruby environment
+. /etc/profile.d/rvm.sh
+# Use a gemset unique to each executor to enable parallel builds
+gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
+rvm use ruby-${ruby}@${gemset} --create
+rvm gemset empty --force
+#gem update --no-ri --no-rdoc
+gem install bundler --no-ri --no-rdoc
+
+# Retry as rubygems (being external to us) can be intermittent
+while ! bundle install -j 5; do
+  (( c += 1 ))
+  if [ $c -ge 5 ]; then
+    echo "bundle install continually failed" >&2
+    exit 1
+  fi
+done
+
+# compile site on slave
+bundle exec jekyll build 
+
+# Copy the site to the web node
+# Dependencies
+# * the slave must have the web::uploader class
+# * the web node must have the web class
+
+# Sync to the pivot-point on the web node
+TARGET_PATH="website@theforeman.org:rsync_cache/"
+
+# Export this to avoid quoting issues
+export RSYNC_RSH="ssh -i /var/lib/workspace/workspace/rsync_web_key"
+
+/usr/bin/rsync -acvxz --delete-after ./_site/ $TARGET_PATH

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/gemset_cleanup.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/gemset_cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+ruby=2.0.0
+# Clean gemset and database
+. /etc/profile.d/rvm.sh
+gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
+rvm use ruby-${ruby}@${gemset}
+rvm gemset delete ${gemset} --force
+exit 0

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/gemset_cleanup_proxy.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/gemset_cleanup_proxy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+# Clean RVM Ruby environment
+. /etc/profile.d/rvm.sh
+gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
+rvm use ruby-${ruby}
+rvm gemset delete ${gemset} --force

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/systest_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/systest_foreman.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -xe
+
+rm -f *.bats.out || true
+
+if [ ${os#f} != $os ]; then
+  osname=Fedora
+  osver=${os#f}
+  [ $repo != nightly ] && FOREMAN_REPO=releases/$repo
+  args="FOREMAN_CUSTOM_URL=http://koji.katello.org/releases/yum/foreman-${repo}/${osname}/${osver}/x86_64/ FOREMAN_REPO=$FOREMAN_REPO"
+elif [ ${os#el} != $os ]; then
+  osname=RHEL
+  osver=${os#el}
+  [ $repo != nightly ] && FOREMAN_REPO=releases/$repo
+  args="FOREMAN_CUSTOM_URL=http://koji.katello.org/releases/yum/foreman-${repo}/${osname}/${osver}/x86_64/ FOREMAN_REPO=$FOREMAN_REPO"
+else
+  args="FOREMAN_CUSTOM_URL=http://stagingdeb.theforeman.org/ FOREMAN_REPO=theforeman-${repo}"
+fi
+
+if [ $run_hammer_tests = true ]; then
+  args="FOREMAN_USE_ORGANIZATIONS=true FOREMAN_USE_LOCATIONS=true $args"
+fi
+
+export VAGRANT_DEFAULT_PROVIDER=rackspace
+
+trap "vagrant destroy" EXIT ERR
+
+vagrant up $os
+
+PUPPET_REPO=stable
+[ $nightly_puppet = true ] && PUPPET_REPO=nightly
+if [ $pl_puppet = true -o $os = precise ]; then
+  echo PUPPET_REPO=${PUPPET_REPO} fb-install-plpuppet.bats | vagrant ssh $os | tee fb-install-plpuppet.bats.out
+fi
+
+echo ${args} fb-install-foreman.bats | vagrant ssh $os | tee fb-install-foreman.bats.out
+
+if [ $run_hammer_tests = true ]; then
+  if [ "x$hammer_deps" != "x" ]; then
+    echo "cd ~/ && wget https://gist.githubusercontent.com/tstrachota/52b86d7ccf835a11dc99/raw/install_gems.sh" | vagrant ssh $os
+    hammer_deps=$(echo -e $hammer_deps | tr "\n" " ")
+    echo "Hammer deps: ${hammer_deps}"
+    echo "bash ~/install_gems.sh ${hammer_deps}" | vagrant ssh $os
+  fi
+
+  hammer_test_args="HAMMER_TEST_BRANCH=${hammer_tests_branch}" 
+  hammer_test_args="HAMMER_TEST_REPO=https://github.com/${hammer_tests_owner}/hammer-tests.git ${hammer_test_args}"
+  echo $hammer_test_args fb-hammer-tests.bats | vagrant ssh $os | tee fb-hammer-tests.bats.out
+fi
+
+[ -e debug ] && rm -rf debug/
+mkdir debug
+vagrant ssh-config $os > ssh_config
+scp -F ssh_config ${os}:/root/last_logs debug/ || true
+scp -F ssh_config ${os}:/root/sosreport* debug/ || true
+scp -F ssh_config ${os}:/root/foreman-debug* debug/ || true
+scp -F ssh_config ${os}:/root/hammer_test_logs/* debug/ || true
+
+exit 0

--- a/puppet/modules/jenkins_job_builder/files/config/scripts/test/proxy.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/test/proxy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+
+APP_ROOT=`pwd`
+
+# setup basic settings file
+cp $APP_ROOT/config/settings.yml.example $APP_ROOT/config/settings.yml
+
+# RVM Ruby environment
+. /etc/profile.d/rvm.sh
+# Use a gemset unique to each executor to enable parallel builds
+gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
+rvm use ruby-${ruby}@${gemset} --create
+rvm gemset empty --force
+# Update any gems from the global gemset
+gem update --no-ri --no-rdoc
+gem install bundler --no-ri --no-rdoc
+
+# Puppet environment
+sed -i "/^\s*gem.*puppet/ s/\$/, '~> $puppet'/" $APP_ROOT/bundler.d/puppet.rb
+
+bundle install --without=development
+bundle exec rake pkg:generate_source jenkins:unit

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/builders/build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/builders/build_deb_coreproject.yaml
@@ -1,0 +1,6 @@
+- builder:
+    name: build_deb_coreproject
+    builders:
+      - shell: !include-raw scripts/debian/configure_pbuilder.sh
+      - shell: !include-raw scripts/debian/execute_pbuilder.sh
+      - shell: !include-raw scripts/debian/stage_packages.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/builders/deploy_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/builders/deploy_deb.yaml
@@ -1,0 +1,4 @@
+- builder:
+    name: deploy_deb
+    builders:
+      - shell: !include-raw scripts/debian/deploy_deb.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/builders/deploy_web.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/builders/deploy_web.yaml
@@ -1,0 +1,4 @@
+- builder:
+    name: deploy_web
+    builders:
+      - shell: !include-raw scripts/deploy_web.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/builders/systest_foreman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/builders/systest_foreman.yaml
@@ -1,0 +1,4 @@
+- builder:
+    name: systest_foreman
+    builders:
+      - shell: !include-raw scripts/systest_foreman.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/builders/test_proxy.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/builders/test_proxy.yaml
@@ -1,0 +1,4 @@
+- builder:
+    name: test_proxy
+    builders:
+      - shell: !include-raw scripts/test/proxy.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/defaults/defaults.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/defaults/defaults.yaml
@@ -1,0 +1,16 @@
+##############################################################################
+####   Defaults
+###############################################################################
+- defaults:
+    description: |
+      This job is automatically updated by jenkins job builder, any manual
+      change will be lost in the next update. If you want to make permanent
+      changes, check out the <a href="http://github.com/theforeman/foreman-infra">infra</a> repo.
+    name: global
+    project-type: freestyle
+    concurrent: false
+    logrotate:
+      numToKeep: 3
+    wrappers:
+      - timestamps
+

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/deploy_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/deploy_deb.yaml
@@ -1,0 +1,20 @@
+- job:
+    name: deploy_deb
+    node: 'debian'
+    scm:
+      - foreman-infra
+    builders:
+      - deploy_deb
+    parameters:
+      - string:
+          name: os
+          default: wheezy
+          description: 'OS code, e.g. <code>wheezy</code>, <code>trusty</code>'
+      - string:
+          name: repo
+          default: nightly
+          description: 'Repo on staging-deb to consume. This will have "theforeman-" prefixed automatically, so e.g. nightly, 1.6'
+    wrappers:
+      - timeout:
+          timeout: 30
+          type: absolute

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/deploy_web.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/deploy_web.yaml
@@ -1,0 +1,12 @@
+- job:
+    name: deploy_web
+    node: 'admin && sshkey'
+    scm:
+      - theforeman.org
+    triggers:
+      - github
+      - pollscm: '*/5 * * * *'
+    builders:
+      - deploy_web
+    publishers:
+      - gemset_cleanup

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -1,0 +1,73 @@
+- job:
+    name: packaging_build_deb_coreproject
+    project-type: matrix
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-packaging/
+    scm:
+      - foreman-deb-packaging
+    axes:
+      - axis:
+          type: user-defined
+          name: os
+          values:
+          - wheezy
+          - precise
+          - squeeze
+          - trusty
+      - axis:
+          type: slave
+          name: label
+          values:
+          - debian
+    execution-strategy:
+      combination-filter: '(onlyos == "all" && os != "squeeze") || onlyos == "os"'
+    builders:
+      - build_deb_coreproject
+    publishers:
+      - pbuilder_cleanup
+    parameters:
+      - string:
+          name: repoowner
+          default: theforeman
+          description: 'GitHub username/org containing the repo, useful to change for scratch builds.<br/>
+Any value other than "theforeman" will be pushed to http://stagingdeb.theforeman.org for testing.'
+      - choice:
+          name: project
+          choices:
+            - foreman
+            - foreman-proxy
+            - foreman-installer
+          description: 'Which main project to build'
+      - choice:
+          name: onlyos
+          choices:
+            - all
+            - wheezy
+            - precise
+            - squeeze
+            - trusty
+          description: 'Restrict matrix job to just the one OS.'
+      - string:
+          name: repo
+          default: develop
+          description: 'Name of the sub-branch under foreman-packaging/deb to use (usually "develop" or a release name e.g. "1.2")'
+      - string:
+          name: version
+          default: nightly
+          description: 'Version of foreman being built. Primarily for apt component generation.  e.g. "nightly", "1.6"'
+      - bool:
+          name: gitrelease
+          default: true
+          description: 'Whether to label the build as a git build with a SHA as an extra changelog entry.  This <b>must</b> be disabled for releases (RC or final).'
+      - choice:
+          name: nightly_jenkins_job
+          choices:
+            - test_develop
+            - test_proxy_develop
+            - packaging_trigger_installer_develop
+          description: 'When building nightly (develop), name of the Jenkins job that contains the source file(s) (tarballs, gems) to build, e.g. test_develop'
+      - string:
+          name: nightly_jenkins_job_id
+          default: lastSuccessfulBuild
+          description: 'When building nightly (develop), the build number for the Jenkins job (above) or an alias, e.g. 123, lastSuccessfulBuild'

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/release_nightly_build_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/release_nightly_build_deb.yaml
@@ -1,0 +1,36 @@
+- job:
+    name: release_nightly_build_deb
+    node: 'admin'
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-packaging/
+    builders:
+      - trigger-builds:
+        - project: packaging_build_deb_coreproject
+          predefined-parameters: |
+            repoowner=theforeman
+            project=${project}
+            onlyos=all
+            repo=develop
+            version=nightly
+            gitrelease=true
+            nightly_jenkins_job=${jenkins_job}
+            nightly_jenkins_job_id=${jenkins_job_id}
+          block: true
+    parameters:
+      - string:
+          name: project
+          default: 
+          description: 'Name of the project GitHub repo to build'
+      - string:
+          name: jenkins_job
+          default: 
+          description: 'Name of the Jenkins job that contains the source file(s) (tarballs, gems) to build, e.g. test_develop'
+      - string:
+          name: jenkins_job_id
+          default: lastSuccessfulBuild
+          description: 'When building nightly (develop), the build number for the Jenkins job (above) or an alias, e.g. 123, lastSuccessfulBuild'
+    publishers:
+      - trigger:
+          project: release_nightly_test_deb
+          threshold: SUCCESS

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/release_nightly_push_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/release_nightly_push_deb.yaml
@@ -1,0 +1,19 @@
+- job:
+    name: release_nightly_push_deb
+    project-type: matrix
+    builders:
+      - trigger-builds:
+        - project: deploy_deb
+          predefined-parameters: "os=${os}\nrepo=nightly"
+          block: true
+    axes:
+      - axis:
+          type: user-defined
+          name: os
+          values:
+          - wheezy
+          - precise
+          - squeeze
+          - trusty
+    publishers:
+      - ircbot_freenode

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/release_nightly_test_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/release_nightly_test_deb.yaml
@@ -1,0 +1,21 @@
+- job:
+    name: release_nightly_test_deb
+    project-type: matrix
+    builders:
+      - trigger-builds:
+        - project: systest_foreman
+          predefined-parameters: "os=${os}\nrepo=nightly\npl_puppet=true"
+          block: true
+    axes:
+      - axis:
+          type: user-defined
+          name: os
+          values:
+          - wheezy
+          - precise
+          - trusty
+    publishers:
+      - trigger:
+          project: release_nightly_push_deb
+          threshold: SUCCESS
+      - ircbot_freenode

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/systest_foreman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/systest_foreman.yaml
@@ -1,0 +1,49 @@
+- job:
+    name: systest_foreman
+    node: 'el6'
+    scm:
+      - foreman-bats
+    builders:
+      - systest_foreman
+    wrappers:
+      - timeout:
+          timeout: 60
+          type: absolute
+    parameters:
+      - string:
+          name: repo
+          default: nightly
+          description: 'Repo on koji / stagingdeb to test. Prefixes appropriate to the test repo is automatically added ("foreman" for koji, "theforeman" for stagingdeb), so use only the variable component, e.g. <code>nightly</code> or <code>1.6</code>'
+      - string:
+          name: os
+          default: ''
+          description: 'OS code, e.g. <code>el6</code>, <code>f18</code>, <code>wheezy</code>'
+      - bool:
+          name: pl_puppet
+          default: false
+          description: 'Whether to install Puppet from Puppet Labs first, instead of using the distro version.'
+      - bool:
+          name: nightly_puppet
+          default: false
+          description: 'Whether to enable nightly Puppet repos, use in addition to pl_puppet.'
+      - bool:
+          name: run_hammer_tests
+          default: false
+          description: 'Whether to run additional hammer tests (https://github.com/theforeman/hammer-tests).'
+      - string:
+          name: hammer_tests_owner
+          default: theforeman
+          description: ''
+      - string:
+          name: hammer_tests_branch
+          default: master
+          description: ''
+      - string:
+          name: hammer_deps
+          default: ''
+          description: 'Install additional gem dependencies for hammer tests. Can be used for testing your own branches.  Whitespace separated list of gem names or git urls in format <code>https://github.com/owner/repo.git#name_of_branch</code>.
+
+E.g.
+<code>https://github.com/theforeman/hammer-cli.git#test</code>'
+    publishers:
+      - systest_foreman

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/test_proxy_develop.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/jobs/test_proxy_develop.yaml
@@ -1,0 +1,45 @@
+- job:
+    name: test_proxy_develop
+    project-type: matrix
+    properties:
+      - github:
+          url: https://github.com/theforeman/smart-proxy
+    scm:
+      - foreman-proxy
+    triggers:
+      - github
+      - pollscm: '*/5 * * * *'
+    axes:
+      - axis:
+          type: user-defined
+          name: ruby
+          values:
+          - 1.8.7
+          - 1.9.2
+          - 1.9.3
+          - 2.0.0
+          - 2.1
+      - axis:
+          type: user-defined
+          name: puppet
+          values:
+          - 2.6.0
+          - 2.7.0
+          - 3.0.0
+          - 3.4.0
+          - 3.7.0
+    execution-strategy:
+      combination-filter: '!( (ruby ==~ /(1\.9|2).*/ && puppet ==~ /2\.6.*/) || (ruby ==~ /2.*/ && puppet ==~ /(2|3\.[01]).*/) || (ruby ==~ /2.[^0]*/ && puppet ==~ /(2|3\.[0-4]).*/) )'
+    builders:
+      - test_proxy
+    publishers:
+    - gemset_cleanup_proxy
+    - archive:
+        artifacts: 'pkg/*'
+    - trigger-parameterized-builds:
+      - project: release_nightly_build_rpm, release_nightly_build_deb
+        condition: SUCCESS
+        predefined-parameters: |
+          project=foreman-proxy
+          jenkins_job=${JOB_NAME}
+          jenkins_job_id=${BUILD_NUMBER}

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/gemset_cleanup.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/gemset_cleanup.yaml
@@ -1,0 +1,10 @@
+- publisher:
+    name: gemset_cleanup
+    publishers:
+    - post-tasks:
+        - matches: 
+          - log-text: ""
+            operator: AND
+          escalate-status: false
+          run-if-job-successful: false
+          script: !include-raw scripts/gemset_cleanup.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/gemset_cleanup_proxy.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/gemset_cleanup_proxy.yaml
@@ -1,0 +1,10 @@
+- publisher:
+    name: gemset_cleanup_proxy
+    publishers:
+    - post-tasks:
+        - matches: 
+          - log-text: ""
+            operator: AND
+          escalate-status: false
+          run-if-job-successful: false
+          script: !include-raw scripts/gemset_cleanup_proxy.sh

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/ircbot_freenode.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/ircbot_freenode.yaml
@@ -1,0 +1,15 @@
+- publisher:
+    name: ircbot_freenode
+    publishers:
+    - ircbot:
+        strategy: failure-and-fixed
+        notify-start: false
+        notify-committers: false
+        notify-culprits: false
+        notify-upstream: false
+        notify-fixers: false
+        message-type: summary
+        channels:
+            - name: '#theforeman-dev'
+              notify-only: true
+        matrix-notifier: only-configurations

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/pbuilder_cleanup.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/pbuilder_cleanup.yaml
@@ -1,0 +1,11 @@
+- publisher:
+    name: pbuilder_cleanup
+    publishers:
+    - post-tasks:
+        - matches:
+          - log-text: ".*"
+            operator: AND
+          escalate-status: false
+          run-if-job-successful: false
+          script: "sudo chown -R jenkins:jenkins ./"
+

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/systest_foreman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/publishers/systest_foreman.yaml
@@ -1,0 +1,12 @@
+- publisher:
+    name: systest_foreman
+    publishers:
+    - archive:
+        artifacts: '*.tar.gz'
+        allow-empty: true
+    - tap:
+        results: '*.bats.out'
+        fail-if-no-results: true
+        failed-tests-mark-build-as-failure: true
+        enable-subtests: false
+        todo-is-failure: false

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-bats.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-bats.yaml
@@ -1,0 +1,8 @@
+- scm:
+    name: foreman-bats
+    scm:
+      - git:
+         url: git://github.com/theforeman/foreman-bats.git
+         wipe-workspace: false
+         branches:
+          - '**'

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-infra.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-infra.yaml
@@ -1,0 +1,8 @@
+- scm:
+    name: foreman-infra
+    scm:
+      - git:
+         url: git://github.com/theforeman/foreman-infra.git
+         wipe-workspace: false
+         branches:
+          - master

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-packaging.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-packaging.yaml
@@ -1,0 +1,20 @@
+- scm:
+    name: foreman-deb-packaging
+    scm:
+      - git:
+         url: git://github.com/theforeman/foreman-packaging.git
+         recursive-submodules: true
+         skip-tag: true
+         git-config-name: Jenkins
+         git-config-email: 'packaging@theforeman.org'
+         branches:
+          - '*/deb/develop'
+- scm:
+    name: foreman-rpm-packaging
+    scm:
+      - git:
+         url: git://github.com/theforeman/foreman-packaging.git
+         recursive-submodules: true
+         skip-tag: true
+         branches:
+          - '*/rpm/develop'

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-proxy.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/scm/foreman-proxy.yaml
@@ -1,0 +1,7 @@
+- scm:
+    name: foreman-proxy
+    scm:
+      - git:
+         url: git://github.com/theforeman/smart-proxy.git
+         branches:
+          - 'develop'

--- a/puppet/modules/jenkins_job_builder/files/config/yaml/scm/theforeman.org.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/scm/theforeman.org.yaml
@@ -1,0 +1,8 @@
+- scm:
+    name: theforeman.org
+    scm:
+      - git:
+         url: git://github.com/theforeman/theforeman.org.git
+         wipe-workspace: false
+         branches:
+          - gh-pages

--- a/puppet/modules/jenkins_job_builder/manifests/init.pp
+++ b/puppet/modules/jenkins_job_builder/manifests/init.pp
@@ -1,0 +1,68 @@
+# Class to install, configure, and maintain JJB, as well
+# as to deploy the actual jobs to jenkins
+#
+# Loosely based on
+# https://git.openstack.org/cgit/openstack-infra/puppet-jenkins/tree/manifests/job_builder.pp
+# and should probably be kept up to date from there
+#
+# $run is our addition and is so named becuase noop is a bit too magic in puppet syntax...
+#
+class jenkins_job_builder (
+  $url = '',
+  $username = '',
+  $password = '',
+  $config_dir = '',
+  $run = 'false',
+) {
+
+  if ! defined(Package['jenkins-job-builder']) {
+    package { 'jenkins-job-builder':
+      ensure   => present,
+      provider => 'pip',
+    }
+  }
+
+  file { '/etc/jenkins_jobs':
+    ensure => directory,
+  }
+
+  file { '/etc/jenkins_jobs/config':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    recurse => true,
+    purge   => true,
+    force   => true,
+    source  => $config_dir,
+    notify  => Exec['jenkins_jobs_update'],
+  }
+
+  # test for a string here since it's annoyingly hard to pass a boolean from foreman via yaml
+  if $run == 'false' {
+    $cmd = "jenkins-jobs test /etc/jenkins_jobs/config > /var/cache/jjb.xml"
+  }else{
+    $cmd = "jenkins-jobs update /etc/jenkins_jobs/config > /var/cache/jjb.xml"
+    # eventually we may wish to nuke unmanaged jobs:
+    #$cmd = "jenkins-jobs update --delete-old /etc/jenkins_jobs/config > /var/cache/jjb.xml"
+  }
+
+  exec { 'jenkins_jobs_update':
+    command     => $cmd,
+    timeout     => '600',
+    path        => '/bin:/usr/bin:/usr/local/bin',
+    refreshonly => true,
+    require     => [
+      File['/etc/jenkins_jobs/jenkins_jobs.ini'],
+      Package['jenkins-job-builder'],
+    ],
+  }
+
+# TODO: We should put in  notify Exec['jenkins_jobs_update']
+#       at some point, but that still has some problems.
+  file { '/etc/jenkins_jobs/jenkins_jobs.ini':
+    ensure  => present,
+    mode    => '0400',
+    content => template('jenkins_job_builder/jenkins_jobs.ini.erb'),
+  }
+}

--- a/puppet/modules/jenkins_job_builder/templates/jenkins_jobs.ini.erb
+++ b/puppet/modules/jenkins_job_builder/templates/jenkins_jobs.ini.erb
@@ -1,0 +1,11 @@
+[jenkins]
+user=<%= username %>
+password=<%= password %>
+url=<%= url %>
+
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:/etc/jenkins_jobs/config
+recursive=True
+allow_duplicates=False


### PR DESCRIPTION
Installs JJB from PiP
Deploys config file
Deploys Job YAML from puppet
Calls 'jjb test' and redirects to /tmp for evaluation

Currently just implements deploy_web as a simple case, and the deb half of the proxy pipeline. You'll need to add the view yourself once the jobs are deployed (if you build a test jenkins which doesn't have the view defined). There is an analogous jenkins-view-builder, but it seems buggy, so I'll leave that for a future PR.

You can apply it via
```
class { 'jenkins_job_builder':
  url      => 'http://192.168.122.2:8080',
  username => 'user',
  password => 'changeme',
  config_dir => 'puppet:///modules/jenkins_job_builder/config'
}
```
Clearly the user/pw are a user with write access to create/update jobs. Installing 1.1.0 from PiP seems sufficient for now, so I dropped the VCS install from the Openstack version of the module. Chance are we'll need to revert to VCS mode and fork JJB so we can add the modules we need to configure (eg, the scheduled rebuild plugin) but this gets us started.

Likely to be a lot of non-DRY yaml in here, as I was just implementing jobs one at a time. Fixes welcome, or we can do that in another PR.