### PR TITLE
Manage and update rubygems version in rvm environments

### DIFF
--- a/puppet/modules/slave/manifests/rvm_config.pp
+++ b/puppet/modules/slave/manifests/rvm_config.pp
@@ -1,13 +1,20 @@
-define slave::rvm_config($version) {
+define slave::rvm_config($version, $rubygems_version = '2.4.5') {
   $alias = $title
 
   rvm_system_ruby { $version:
     ensure => present,
-  }
-
+  } ->
   rvm_alias { $alias:
     ensure      => present,
     target_ruby => $version,
-    require     => Rvm_system_ruby[$version],
+  } ->
+  rvm_gem { "${version}/rubygems-update":
+    ensure => $rubygems_version,
+  } ~>
+  exec { "${version}/update_rubygems":
+    command  => "rvm ${version} do update_rubygems",
+    unless   => "test `rvm ${version} do gem -v` = ${rubygems_version}",
+    path     => '/usr/local/rvm/bin:/usr/bin:/bin',
+    provider => 'shell',
   }
 }


### PR DESCRIPTION
Tested manually on one of the slaves:

<pre>
[dcleal@foreman-build ~]$ rvm use ruby-1.8.7
Using /usr/local/rvm/gems/ruby-1.8.7-p371
[dcleal@foreman-build ~]$ gem -v
1.8.25
[dcleal@foreman-build ~]$ sudo puppet apply rvm.pp -v
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for foreman-build.kywimax.com in environment production in 0.05 seconds
Info: Applying configuration version '1423656529'
Notice: /Stage[main]/Main/Rvm_gem[ruby-1.8.7-p371/rubygems-update]/ensure: created
Info: /Stage[main]/Main/Rvm_gem[ruby-1.8.7-p371/rubygems-update]: Scheduling refresh of Exec[ruby-1.8.7-p371/update_rubygems]
Notice: /Stage[main]/Main/Exec[ruby-1.8.7-p371/update_rubygems]/returns: executed successfully
Notice: /Stage[main]/Main/Exec[ruby-1.8.7-p371/update_rubygems]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 23.99 seconds
[dcleal@foreman-build ~]$ gem -v
2.4.5
[dcleal@foreman-build ~]$ sudo puppet apply rvm.pp -v
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for foreman-build.kywimax.com in environment production in 0.06 seconds
Info: Applying configuration version '1423656564'
Notice: Finished catalog run in 0.90 seconds
</pre>

This should make our rubygems version consistent in every environment, avoiding https://github.com/bundler/bundler/issues/3385 which was seen with old thread-unsafe versions.