### PR TITLE
Switch JJB to a git clone, for ease of coding new plugin xml changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "puppet/modules/apt"]
 	path = puppet/modules/apt
 	url = https://github.com/puppetlabs/puppetlabs-apt.git
+[submodule "puppet/modules/vcsrepo"]
+	path = puppet/modules/vcsrepo
+	url = https://github.com/puppetlabs/puppetlabs-vcsrepo


### PR DESCRIPTION
This is so we can use things like http://www.larrycaiyu.com/blog/2014/01/14/extend-jenkins-job-builder/ on our fork of JJB to add plugins we use in Jenkins.