### PR TITLE
Add scheduled jjb run for reverting manual changes

### DIFF
--- a/puppet/modules/jenkins_job_builder/manifests/init.pp
+++ b/puppet/modules/jenkins_job_builder/manifests/init.pp
@@ -84,6 +84,26 @@ class jenkins_job_builder (
     ],
   }
 
+  # copy of the first exec to run on a regular schedule, in the early morning
+  # this can be removed once all job changes are going through JJB, but for now
+  # it will ensure any manual changes to jobs will be reverted
+  schedule { 'jenkins':
+    range  => '2 - 4',
+    period => daily,
+    repeat => 1,
+  }
+  exec { 'jenkins_jobs_update_scheduled':
+    command  => $cmd,
+    timeout  => $jenkins_jobs_update_timeout,
+    path     => '/bin:/usr/bin:/usr/local/bin',
+    schedule => 'jenkins',
+    require  => [
+      File['/etc/jenkins_jobs/jenkins_jobs.ini'],
+      Package['python-jenkins'],
+      Package['PyYAML'],
+    ],
+  }
+
 # TODO: We should put in  notify Exec['jenkins_jobs_update']
 #       at some point, but that still has some problems.
   file { '/etc/jenkins_jobs/jenkins_jobs.ini':


### PR DESCRIPTION
Seems to work:
```
[root@centos1010 foreman-infra.greg]# puppet apply -vt --modulepath /root/foreman-infra.greg/puppet/modules/ /root/test.pp  --no-noop
Info: Loading facts
Notice: Compiled catalog for centos1010.sapphire.elysium.emeraldreverie.org in environment production in 1.90 seconds
Info: Applying configuration version '1426249242'
Notice: Finished catalog run in 16.03 seconds
[root@centos1010 foreman-infra.greg]# date 03130235
Fri Mar 13 02:35:00 UTC 2015
[root@centos1010 foreman-infra.greg]# puppet apply -vt --modulepath /root/foreman-infra.greg/puppet/modules/ /root/test.pp  --no-noop
Info: Loading facts
Notice: Compiled catalog for centos1010.sapphire.elysium.emeraldreverie.org in environment production in 1.92 seconds
Info: Applying configuration version '1426214104'
Notice: /Stage[main]/Jenkins_job_builder/Exec[jenkins_jobs_update_scheduled]/returns: executed successfully
Notice: Finished catalog run in 16.47 seconds
```
