### PR TITLE
[jjb] Fix formatting in katello.org SCM yaml

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/config/yaml/scm/katello.org.yaml
+++ b/puppet/modules/jenkins_job_builder/files/config/yaml/scm/katello.org.yaml
@@ -5,7 +5,7 @@
          url: git://github.com/Katello/katello.org.git
          wipe-workspace: false
          branches:
-          - master
-          - */Katello-2.0
-          - */Katello-2.1
-          - */Katello-2.2
+          - 'master'
+          - '*/Katello-2.0'
+          - '*/Katello-2.1'
+          - '*/Katello-2.2'


### PR DESCRIPTION
JJB doesn't like the bare / it seems:
```
yaml.scanner.ScannerError: while scanning an alias
in "/etc/jenkins_jobs/config/yaml/scm/katello.org.yaml", line 9, column 13
expected alphabetic or numeric character, but found '/'
in "/etc/jenkins_jobs/config/yaml/scm/katello.org.yaml", line 9, column 14
```