### PR TITLE
don't use PL repo for Debian/jessie

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/config/scripts/systest_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/config/scripts/systest_foreman.sh
@@ -35,7 +35,7 @@ vagrant up $os
 
 PUPPET_REPO=stable
 [ $nightly_puppet = true ] && PUPPET_REPO=nightly
-if [ $pl_puppet = true -o $os = precise ]; then
+if [ $pl_puppet = true -a ! $os = jessie -o $os = precise ]; then
   echo PUPPET_REPO=${PUPPET_REPO} fb-install-plpuppet.bats | vagrant ssh $os | tee fb-install-plpuppet.bats.out
 fi
 


### PR DESCRIPTION
The "jessie" repo was empty anyway (besides puppetlabs-release), and "testing"
repos were filled. However, now even puppetlabs-release was pulled from
apt.puppetlabs.com index, so fb-install-plpuppet.bats would always fail.