### PR TITLE
Add openscap repo data and install openscap

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -162,6 +162,19 @@ class slave($github_user = undef,
     }
   }
 
+  # Needed by foreman_openscap gem dependency OpenSCAP
+  if $osfamily == 'RedHat' {
+    yumrepo { 'isimluk-openscap':
+      enabled     => 1,
+      gpgcheck    => 0,
+      baseurl     => "http://copr-be.cloud.fedoraproject.org/results/isimluk/OpenSCAP/epel-${::operatingsystemmajrelease}-\$basearch/",
+      includepkgs => ['openscap'],
+    } ->
+    package { 'openscap':
+      ensure => latest,
+    }
+  }
+
   # specs-from-koji
   if $osfamily == 'RedHat' {
     package {


### PR DESCRIPTION
What I'd like to achieve: __Installing OpenSCAP on the slave servers.__
How: Adding openscap repo data to the slave puppet.

~~Please note related PR: https://github.com/theforeman/puppet-foreman/pull/326
Which will require a version bump for foreman-infra/modules/foreman submodule.~~