### PR TITLE
Move Apache vhost logs to /var/log

### DIFF
--- a/puppet/modules/apache/manifests/debian.pp
+++ b/puppet/modules/apache/manifests/debian.pp
@@ -9,7 +9,7 @@ class apache::debian inherits apache::base {
   }
 
   # the following variables are used in template logrotate-httpd.erb
-  $logrotate_paths = "${apache::params::root}/*/logs/*.log ${apache::params::log}/*log"
+  $logrotate_paths = "${apache::params::log}/*log"
   $httpd_pid_file = "/var/run/apache2.pid"
   $httpd_reload_cmd = "/etc/init.d/apache2 restart > /dev/null"
   $awstats_condition = "-f /usr/share/doc/awstats/examples/awstats_updateall.pl -a -f /usr/lib/cgi-bin/awstats.pl"

--- a/puppet/modules/apache/manifests/redhat.pp
+++ b/puppet/modules/apache/manifests/redhat.pp
@@ -18,7 +18,7 @@ class apache::redhat inherits apache::base {
   }
 
   # the following variables are used in template logrotate-httpd.erb
-  $logrotate_paths = "${apache::params::root}/*/logs/*.log ${apache::params::log}/*log"
+  $logrotate_paths = "${apache::params::log}/*log"
   $httpd_pid_file = $::lsbmajdistrelease ? {
     /4|5/   => '/var/run/httpd.pid',
     default => '/var/run/httpd/httpd.pid',

--- a/puppet/modules/apache/manifests/vhost.pp
+++ b/puppet/modules/apache/manifests/vhost.pp
@@ -30,6 +30,7 @@ define apache::vhost (
 
   # used in ERB templates
   $wwwroot = $apache::params::root
+  $logroot = $apache::params::log
 
   $documentroot = $docroot ? {
     false   => "${wwwroot}/${name}/htdocs",
@@ -153,23 +154,10 @@ define apache::vhost (
       }
 
       # Log files
-      file {"${apache::params::root}/${name}/logs":
-        ensure => directory,
-        owner  => root,
-        group  => root,
-        mode   => '0755',
-        seltype => $::operatingsystem ? {
-          redhat => 'httpd_log_t',
-          CentOS => 'httpd_log_t',
-          default => undef,
-        },
-        require => File["${apache::params::root}/${name}"],
-      }
-
       # We have to give log files to right people with correct rights on them.
       # Those rights have to match those set by logrotate
-      file { ["${apache::params::root}/${name}/logs/access.log",
-              "${apache::params::root}/${name}/logs/error.log"] :
+      file { ["${apache::params::log}/${name}_access.log",
+              "${apache::params::log}/${name}_error.log"] :
         ensure => present,
         owner => root,
         group => adm,
@@ -179,7 +167,6 @@ define apache::vhost (
           CentOS => 'httpd_log_t',
           default => undef,
         },
-        require => File["${apache::params::root}/${name}/logs"],
       }
 
       # Private data
@@ -222,7 +209,6 @@ define apache::vhost (
           default => Package[$apache::params::pkg]},
           File["${apache::params::conf}/sites-available/${name}"],
           File["${apache::params::root}/${name}/htdocs"],
-          File["${apache::params::root}/${name}/logs"],
           File["${apache::params::root}/${name}/conf"]
         ],
         unless  => "/bin/sh -c '[ -L ${apache::params::conf}/sites-enabled/${name} ] \\

--- a/puppet/modules/apache/templates/vhost-ssl.erb
+++ b/puppet/modules/apache/templates/vhost-ssl.erb
@@ -10,8 +10,8 @@
 
   LogLevel warn
 
-  ErrorLog <%= wwwroot %>/<%= name %>/logs/error.log
-  CustomLog <%= wwwroot %>/<%= name %>/logs/access.log combined
+  ErrorLog <%= logroot %>/<%= name %>_error.log
+  CustomLog <%= logroot %>/<%= name %>_access.log combined
 
   Include <%= wwwroot %>/<%= name%>/conf/*.conf
 

--- a/puppet/modules/apache/templates/vhost.erb
+++ b/puppet/modules/apache/templates/vhost.erb
@@ -10,8 +10,8 @@
 
   LogLevel warn
 
-  ErrorLog <%= wwwroot %>/<%= name %>/logs/error.log
-  CustomLog <%= wwwroot %>/<%= name %>/logs/access.log "<%= accesslog_format %>"
+  ErrorLog <%= logroot %>/<%= name %>_error.log
+  CustomLog <%= logroot %>/<%= name %>_access.log "<%= accesslog_format %>"
 
   Include <%= wwwroot %>/<%= name%>/conf/*.conf
 


### PR DESCRIPTION
Current vhost logs are under /var/www/vhosts/*/logs which isn't
accessible to logrotate under SELinux.  Rather than add custom policy
or customise the labelling, move them to the usual /var/log/ location.

--

Should fix lack of logrotation on our web server now.  Please just review, I'll merge it as I'll probably move the existing log files over so we don't lose anything.