### PR TITLE
Use external IP address fact for uploader SSH key access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "puppet/modules/vcsrepo"]
 	path = puppet/modules/vcsrepo
 	url = https://github.com/puppetlabs/puppetlabs-vcsrepo
+[submodule "puppet/modules/external_ip"]
+	path = puppet/modules/external_ip
+	url = https://github.com/nightfly19/puppet-external_ip

--- a/puppet/modules/deploy/manifests/init.pp
+++ b/puppet/modules/deploy/manifests/init.pp
@@ -1,7 +1,7 @@
 class deploy {
   secure_ssh::receiver_setup { 'deploy':
     user           => 'deploypuppet',
-    foreman_search => 'host.name = slave01.rackspace.theforeman.org and name = ipaddress',
+    foreman_search => 'host.name = slave01.rackspace.theforeman.org and name = external_ip4',
     script_content => template('deploy/script.erb'),
   }
 }

--- a/puppet/modules/freight/manifests/user.pp
+++ b/puppet/modules/freight/manifests/user.pp
@@ -12,7 +12,7 @@ define freight::user (
     # script to handle deployment too
     secure_ssh::receiver_setup { $user:
       user           => $user,
-      foreman_search => 'host.hostgroup = Debian and name = ipaddress',
+      foreman_search => 'host.hostgroup = Debian and name = external_ip4',
       script_content => template('freight/rsync_main.erb'),
       ssh_key_name   => "rsync_${user}_key",
     }
@@ -30,7 +30,7 @@ define freight::user (
   } else {
     secure_ssh::rsync::receiver_setup { $user:
       user           => $user,
-      foreman_search => 'host.hostgroup = Debian and name = ipaddress',
+      foreman_search => 'host.hostgroup = Debian and name = external_ip4',
       script_content => template('freight/rsync.erb'),
     }
   }

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -6,7 +6,7 @@ class web($stable = "1.9", $latest = "1.10", $next = "1.11", $htpasswds = {}) {
 
   secure_ssh::rsync::receiver_setup { 'web':
     user           => 'website',
-    foreman_search => 'host = slave01.rackspace.theforeman.org and name = ipaddress',
+    foreman_search => 'host = slave01.rackspace.theforeman.org and name = external_ip4',
     script_content => template('web/rsync.erb')
   }
 


### PR DESCRIPTION
Two new slaves are deployed on OpenStack with floating IPs, which
aren't visible to the slave's networking stack or Facter.

Add a new fact that determines the external IP and use this to restrict
access.

@GregSutcliffe could you take a look please?  You'll see the facts on the two new slaves only have RFC1918 addresses, which are being added to authorized_keys by the secure_ssh module.