### PR TITLE
Ensure libvirt-dev(el) is present on the slave

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -141,6 +141,12 @@ class slave($github_user = undef,
       name   => $::osfamily ? {
         Debian  => 'libaugeas-dev',
         default => 'augeas-devel'
+      };
+    'libvirt-dev':
+      ensure => present,
+      name   => $::osfamily ? {
+        Debian  => 'libvirt-dev',
+        default => 'libvirt-devel'
       }
   }
 


### PR DESCRIPTION
When trying to apply the slave module to a clean Centos 7 and then run the test_develop script, bundle install failed without libvirt-devel installed.