### PR TITLE
Adds Katello as optional step for plugin testing

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -49,6 +49,7 @@ echo "gem '${plugin_name}', :path => '${PLUGIN_ROOT}'" >> bundler.d/Gemfile.loca
 
 # Plugin specifics..
 [ -e ${PLUGIN_ROOT}/script/ci/katello.yml ] && cp ${PLUGIN_ROOT}/script/ci/katello.yml ${PLUGIN_ROOT}/config/katello.yml
+[ -e ${PLUGIN_ROOT}/gemfile.d/${plugin_name}.rb ] && cat ${PLUGIN_ROOT}/gemfile.d/${plugin_name}.rb >> bundler.d/Gemfile.local.rb
 
 # Update dependencies
 while ! bundle update; do


### PR DESCRIPTION
foreman_pipeline plugin requires Katello to run but our Jenkins is not prepared for it. When job on PR is triggered, Jenkins clones Foreman, then clones Foreman Pipeline and tries to build it. To force presence of Katello, Foreman Pipeline has it listed in dependencies to make sure it is available. Unfortunately, it is not possible to specify git source in gemspec, so Jenkins gets Katello from rubygems which causes gem clashes. This should introduce optional step into test_plugin_matrix job which clones Katello's repo