### PR TITLE
Manage SELinux configs for freight and rsync access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -89,3 +89,6 @@
 [submodule "puppet/modules/httpauth"]
 	path = puppet/modules/httpauth
 	url = https://github.com/jamtur01/jamtur01-httpauth.git
+[submodule "puppet/modules/selinux"]
+	path = puppet/modules/selinux
+	url = https://github.com/jfryman/puppet-selinux.git

--- a/puppet/modules/foreman_debug_rsync/files/rsync_debug.te
+++ b/puppet/modules/foreman_debug_rsync/files/rsync_debug.te
@@ -1,0 +1,14 @@
+policy_module(rsync_debug, 1.0)
+
+optional_policy(`
+  require {
+    type public_content_t;
+    type rsync_t;
+  }
+
+  # rsync creates temporary name during upload and then renames
+  create_files_pattern(rsync_t, public_content_t, public_content_t)
+  write_files_pattern(rsync_t, public_content_t, public_content_t)
+  rename_files_pattern(rsync_t, public_content_t, public_content_t)
+  setattr_files_pattern(rsync_t, public_content_t, public_content_t)
+')

--- a/puppet/modules/freight/manifests/user.pp
+++ b/puppet/modules/freight/manifests/user.pp
@@ -90,4 +90,14 @@ define freight::user (
     owner  => 'root',
     group  => 'root',
   }
+
+  if $selinux {
+    include selinux
+
+    # Ensure contexts are correct for content copied between webroot and staging area
+    selinux::fcontext { "fcontext-${user}":
+      context  => 'public_content_t',
+      pathname => "/var/www/${user}(/.*)?",
+    }
+  }
 }

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -4,6 +4,16 @@
 class web($stable = "1.10", $latest = "1.10", $next = "1.11", $htpasswds = {}) {
   include rsync::server
 
+  if $selinux {
+    include selinux
+
+    # Use a non-HTTP specific context to be shared with rsync
+    selinux::fcontext { 'fcontext-www':
+      context  => 'public_content_t',
+      pathname => '/var/www(/.*)?',
+    }
+  }
+
   # WWW
   secure_ssh::rsync::receiver_setup { 'web':
     user           => 'website',


### PR DESCRIPTION
Content stored in the web root should also be accessible via rsync, so
use a shared context.  Freight staing content should all be under the
public content context so it remains correct when copied to the web
roots.

---

This just implements the manually configured SELinux policy changes on web01 in Puppet.  Replaces @lzap's #142.