### PR TITLE
Permit IPv6 access via secure_ssh module

### DIFF
--- a/puppet/modules/deploy/manifests/init.pp
+++ b/puppet/modules/deploy/manifests/init.pp
@@ -1,7 +1,7 @@
 class deploy {
   secure_ssh::receiver_setup { 'deploy':
     user           => 'deploypuppet',
-    foreman_search => 'host.name = slave01.rackspace.theforeman.org and name = external_ip4',
+    foreman_search => 'host.name = slave01.rackspace.theforeman.org and (name = external_ip4 or name = external_ip6)',
     script_content => template('deploy/script.erb'),
   }
 }

--- a/puppet/modules/deploy/templates/auth_keys.erb
+++ b/puppet/modules/deploy/templates/auth_keys.erb
@@ -4,7 +4,7 @@
     array = @allowed_ips
   else
     # Facts hash from Foreman
-    array = @ip_data.values.map{|a| a['external_ip4']}
+    array = @ip_data.values.map{|a| a.values_at('external_ip4', 'external_ip6') }.compact.flatten
   end
 -%>
 <% array.each do |ip| -%>

--- a/puppet/modules/freight/manifests/user.pp
+++ b/puppet/modules/freight/manifests/user.pp
@@ -12,7 +12,7 @@ define freight::user (
     # script to handle deployment too
     secure_ssh::receiver_setup { $user:
       user           => $user,
-      foreman_search => 'host.hostgroup = Debian and name = external_ip4',
+      foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
       script_content => template('freight/rsync_main.erb'),
       ssh_key_name   => "rsync_${user}_key",
     }
@@ -30,7 +30,7 @@ define freight::user (
   } else {
     secure_ssh::rsync::receiver_setup { $user:
       user           => $user,
-      foreman_search => 'host.hostgroup = Debian and name = external_ip4',
+      foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
       script_content => template('freight/rsync.erb'),
     }
   }

--- a/puppet/modules/secure_ssh/templates/auth_keys.erb
+++ b/puppet/modules/secure_ssh/templates/auth_keys.erb
@@ -4,7 +4,7 @@
     array = @allowed_ips
   else
     # Facts hash from Foreman
-    array = @ip_data.values.map{|a| a['external_ip4']}
+    array = @ip_data.values.map{|a| a.values_at('external_ip4', 'external_ip6') }.compact.flatten
   end
 -%>
 <% array.sort.each do |ip| -%>

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -7,7 +7,7 @@ class web($stable = "1.10", $latest = "1.10", $next = "1.11", $htpasswds = {}) {
   # WWW
   secure_ssh::rsync::receiver_setup { 'web':
     user           => 'website',
-    foreman_search => 'host = slave01.rackspace.theforeman.org and name = external_ip4',
+    foreman_search => 'host = slave01.rackspace.theforeman.org and (name = external_ip4 or name = external_ip6)',
     script_content => template('web/rsync.erb')
   }
   apache::vhost { "web":


### PR DESCRIPTION
Use either external_ip4 or IPv6 facts to permit access via SSH keys to
the web server etc, as most Rackspace hosts have v6 connectivity and
some AAAA records.

Should fix deploy_web and other web related things (package builds/pushes) since migrating to web02 and adding the AAAA record.