### PR TITLE
Switch to manual-only tests for forman bug day

### DIFF
--- a/puppet/modules/slave/templates/test_pull_requests_bastion.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_bastion.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "*": {"jenkins_job_name": "test_bastion_pull_request",
                                 "downstream_job_name": "test_bastion",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_foreman.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman.json.erb
@@ -16,7 +16,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": {
         "develop": {
           "jenkins_job_name": "test_develop_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_bootdisk.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_bootdisk.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_discovery.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_discovery.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "develop": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_docker.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_docker.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_host_rundeck.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_host_rundeck.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_openscap.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_openscap.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_packaging.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_packaging.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "packaging_test_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_pipeline.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_pipeline.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_remote_execution.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_remote_execution.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_salt.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_salt.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_setup.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_setup.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_tasks.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_tasks.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_templates.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_templates.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_hammer_cli.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_hammer_cli.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "master": {"jenkins_job_name": "test_hammer_cli_pull_request",
                                 "downstream_job_name": "test_hammer_cli",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_hammer_cli_foreman.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_hammer_cli_foreman.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "master": {"jenkins_job_name": "test_hammer_cli_foreman_pull_request",
                                 "downstream_job_name": "test_hammer_cli_foreman",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_hammer_cli_foreman_discovery.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_hammer_cli_foreman_discovery.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "master": {"jenkins_job_name": "test_hammer_cli_foreman_discovery_pull_request",
                                 "downstream_job_name": "test_hammer_cli_foreman_discovery",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_kafo.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_kafo.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "master": {"jenkins_job_name": "test_kafo_master_pull_request",
                                 "downstream_job_name": "test_kafo_master",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_kafo_parsers.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_kafo_parsers.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "master": {"jenkins_job_name": "test_kafo_parsers_master_pull_request",
                                 "downstream_job_name": "test_kafo_parsers_master",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_katello.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_katello.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "*": {"jenkins_job_name": "test_katello_pull_request",
                                 "downstream_job_name": "test_katello",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_katello_packaging.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_katello_packaging.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "master": {
                     "jenkins_job_name": "packaging_test_pull_request_katello_rpm",

--- a/puppet/modules/slave/templates/test_pull_requests_smart_proxy.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_smart_proxy.json.erb
@@ -14,7 +14,7 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "run_without_trigger": true,
+      "run_without_trigger": false,
       "branches": { "develop": {"jenkins_job_name": "test_proxy_develop_pull_request",
                                 "downstream_job_name": "test_proxy_develop",
                                 "build_token": "<%= jenkins_build_token -%>"

--- a/puppet/modules/slave/templates/test_pull_requests_smart_proxy_abrt.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_smart_proxy_abrt.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_proxy_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_smart_proxy_discovery.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_smart_proxy_discovery.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_proxy_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_smart_proxy_dynflow.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_smart_proxy_dynflow.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_proxy_plugin_pull_request",

--- a/puppet/modules/slave/templates/test_pull_requests_smart_proxy_remote_execution_ssh.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_smart_proxy_remote_execution_ssh.json.erb
@@ -16,7 +16,7 @@
             "name": "test",
             "test_prefix": "Test Results:",
             "allow_multiple": true,
-            "run_without_trigger": true,
+            "run_without_trigger": false,
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_proxy_plugin_pull_request",


### PR DESCRIPTION
As per -dev discussion, this should switch the Jenkins tests to manual-only. We can merge before Monday morn and revert after the bugday is done.