### PR TITLE
Make rsync permissions to work

### DIFF
--- a/puppet/modules/foreman_debug_rsync/manifests/config.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/config.pp
@@ -13,6 +13,8 @@ class foreman_debug_rsync::config {
     list            => 'no',
     uid             => 'nobody',
     gid             => 'nobody',
+    incoming_chmod  => 'Du=rwx,g=rx,o=rx,Fu=rw,g=r,o=r',
+    outgoing_chmod  => 'Du=rwx,g=rx,o=rx,Fu=rw,g=r,o=r',
   }
 
   if $selinux {


### PR DESCRIPTION
It looks like puppet upstream module rsync moved to octal number as defaults
but this was merged into the tooling in 2010 and this was not backported to
stable distribution we use (RHEL7). For this reason, we must set this
explicitly.

Tested with foreman-debug, without this statement:

```
Apr 11 14:57:54 web02.rackspace.theforeman.org xinetd[24899]: START: rsync pid=7161 from=213.175.37.10
Apr 11 14:57:54 web02.rackspace.theforeman.org rsyncd[7161]: connect from nat-pool-brq-t.redhat.com (213.175.37.10)
Apr 11 14:57:54 web02.rackspace.theforeman.org rsyncd[7161]: rsync to debug-incoming/ from nat-pool-brq-t.redhat.com (213.175.3
Apr 11 14:57:54 web02.rackspace.theforeman.org rsyncd[7161]: Invalid "incoming chmod" directive: F644,D755
Apr 11 14:57:54 web02.rackspace.theforeman.org rsyncd[7161]: receiving file list
Apr 11 14:57:56 web02.rackspace.theforeman.org rsyncd[7161]: sent 54 bytes  received 274183 bytes  total size 274036
Apr 11 14:57:56 web02.rackspace.theforeman.org xinetd[24899]: EXIT: rsync status=0 pid=7161 duration=2(sec)
```

It fixes it:

```
Apr 11 15:00:03 web02.rackspace.theforeman.org xinetd[24899]: START: rsync pid=7222 from=125.209.216.167
Apr 11 15:00:03 web02.rackspace.theforeman.org rsyncd[7222]: name lookup failed for 125.209.216.167: Name or service not known
Apr 11 15:00:03 web02.rackspace.theforeman.org rsyncd[7222]: connect from UNKNOWN (125.209.216.167)
Apr 11 15:00:04 web02.rackspace.theforeman.org rsyncd[7222]: rsync on yum/ from UNKNOWN (125.209.216.167)
Apr 11 15:00:04 web02.rackspace.theforeman.org rsyncd[7222]: Invalid "outgoing chmod" directive: 0644
Apr 11 15:00:04 web02.rackspace.theforeman.org rsyncd[7222]: building file list
Apr 11 15:00:44 web02.rackspace.theforeman.org xinetd[24899]: START: rsync pid=7253 from=213.175.37.10
Apr 11 15:00:44 web02.rackspace.theforeman.org rsyncd[7253]: connect from nat-pool-brq-t.redhat.com (213.175.37.10)
Apr 11 15:00:44 web02.rackspace.theforeman.org rsyncd[7253]: rsync to debug-incoming/ from nat-pool-brq-t.redhat.com (213.175.3
Apr 11 15:00:44 web02.rackspace.theforeman.org rsyncd[7253]: receiving file list
Apr 11 15:00:45 web02.rackspace.theforeman.org rsyncd[7253]: sent 54 bytes  received 274111 bytes  total size 273964
```

I can see we also have few more warnings about outcoming flags, perhaps when we
rsync content from this box to another. I can perhaps add those there too.