### PR TITLE
Creates db axis dynamically for test_plugin_matrix

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_discovery.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_discovery.yaml
@@ -1,6 +1,6 @@
 - project:
     name: foreman_discovery
-    repo: foreman_discovery
+    defaults: plugin
     branch:
       - develop:
           foreman_branch: develop

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_pipeline.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_pipeline.yaml
@@ -1,5 +1,6 @@
 - project:
     name: foreman_pipeline
     defaults: plugin
+    dbs: 'postgres sqlite3'
     jobs:
       - 'test_plugin_{name}_{branch}'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_plugin.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_plugin.yaml
@@ -26,6 +26,7 @@
             plugin_branch={branch}
             plugin_name={name}
             foreman_branch={foreman_branch}
+            dbs={dbs}
           block: true
     publishers:
       - ircbot_freenode
@@ -35,3 +36,4 @@
     repo: '{name}'
     branch: master
     foreman_branch: develop
+    dbs: 'postgresql mysql sqlite3'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_plugin_matrix.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_plugin_matrix.yaml
@@ -26,6 +26,10 @@
           name: foreman_branch
           default: develop
           description: "Git branch name of Foreman itself, e.g. <pre>develop</pre>"
+      - string:
+          name: dbs
+          default: 'postgresql mysql sqlite3'
+          description: "Databases to test against"
     concurrent: true
     scm:
       - git:
@@ -44,12 +48,10 @@
             - 2.0.0
             - 2.1
       - axis:
-          type: user-defined
+          type: dynamic
           name: database
           values:
-            - postgresql 
-            - mysql
-            - sqlite3
+            - dbs
       - axis:
           type: label-expression
           name: slave


### PR DESCRIPTION
Allows plugins to specify, which databases to use for test_plugin_matrix. Current behaviour (testing against postgres, mysql and sqlite) is left as a default. The reason behind this is that foreman_pipeline needs Katello, but Katello does not officially support mysql. I have fixed a bunch of migration errors related to foreign keys that appear only on mysql, but I do not see how I could work around [Katello 's index being too long](https://github.com/Katello/katello/blob/master/db/migrate/20150613134559_add_rpm.rb#L20). It Requires Dynamic axis plugin for Jenkins. 