### PR TITLE
web: add daily download metrics filter script

### DIFF
--- a/puppet/modules/web/files/filter_apache_stats.sh
+++ b/puppet/modules/web/files/filter_apache_stats.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Semi-crude script to run daily for doing initial parsing of apache logs to
+# remove lines we definitely don't want. It gets:
+#
+# * only successful requests (code == 200)
+# * only GET requrests
+# * only actual packages (strings ending in .rpm or .deb)
+# * strips out "source", "tfm" and "rubygem" from the rpms to distinguish
+#   foreman packages from dependencies
+#
+# This reduces the apache logs by a factor of about 20, which can then be
+# downloaded for further intensive processing (by date, version, user-agent,
+# etc) - date processing is particularly cpu instensive, so it's best kept off
+# the webserver.
+#
+# This script is intended to run daily on the latest logfile, however, since it
+# is possible that a logrotation has happened overnight, the last *two* files
+# are parsed. Files are datestamped with a one-week cleanup.
+
+debs=`ls -1rt /var/log/httpd/deb_access.log*|tail -n2`
+yums=`ls -1rt /var/log/httpd/yum_access.log*|tail -n2`
+date=`date '+%Y%m%d'`
+ldir='/var/cache/parsed_apache_logs'
+
+mkdir -p $ldir
+
+echo -n "Parsing:"
+echo $debs
+grep "\s200\s" $debs \
+  | grep "\"GET" \
+  | grep "\.deb\s" \
+  > ${ldir}/deb_downloads.${date}.log
+
+echo -n "Parsing:"
+echo $yums
+grep "\s200\s" $yums \
+  | grep "\"GET" \
+  | grep "\.rpm\s" \
+  | grep -v "\/source\/" \
+  | egrep -v "/(releases|nightly)/.*(tfm|rubygem)" \
+  > ${ldir}/yum_downloads.${date}.log
+
+# Clean up old backups over a week old
+find $ldir -mtime +6 -delete

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -120,4 +120,22 @@ class web($stable = "1.11", $latest = "1.11", $next = "1.12", $htpasswds = {}) {
     mode   => 0644,
     source => 'puppet:///modules/web/downloads-HEADER.html',
   }
+
+  # METRICS
+  # script to do initial filtering of apache logs for download metrics
+  file { '/usr/local/bin/filter_apache_stats':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0744',
+    source => 'puppet:///modules/web/filter_apache_stats.sh',
+  }
+
+  # daily at 4am, should be fairly quiet on the server
+  cron { 'filter_apache_stats':
+    command => '/usr/bin/nice -19 /usr/local/bin/filter_apache_stats',
+    user    => root,
+    hour    => '4',
+    minute  => '0'
+  }
 }


### PR DESCRIPTION
This automates something I've been doing manually for a while. Full parsing of the download metrics is CPU-intensive, so I don't want to load the server with that - instead I do some initial filtering server-side to reduce the amount of data to download, and then process that on my laptop. This is the server-side part, so I can just get the latest contents of `/var/cache/parsed_apache_logs` while updating my metrics.

This means we're truncating up to ~2-3Gb of raw logs to ~30-40Mb, which my monthly download allowance is very happy about. Stats for interest's sake:
```
[root@web02 ~]# du -sh /var/log/httpd/{yum_access.log-20160509,yum_access.log,deb_access.log-20160509,deb_access.log}
893M	/var/log/httpd/yum_access.log-20160509
381M	/var/log/httpd/yum_access.log
583M	/var/log/httpd/deb_access.log-20160509
361M	/var/log/httpd/deb_access.log

[root@web02 ~]# time bash /tmp/filter_apache_stats.sh
Parsing:/var/log/httpd/deb_access.log-20160509 /var/log/httpd/deb_access.log
Parsing:/var/log/httpd/yum_access.log-20160509 /var/log/httpd/yum_access.log

real	2m14.748s
user	2m7.734s
sys	0m4.196s

[root@web02 ~]# du -sh /var/cache/parsed_apache_logs/{yum_downloads.20160513.log,deb_downloads.20160513.log}
26M /var/cache/parsed_apache_logs/yum_downloads.20160513.log
6.0M /var/cache/parsed_apache_logs/deb_downloads.20160513.log
```