### PR TITLE
Change 'postgres' to 'postgresql'

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_pipeline.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_pipeline.yaml
@@ -1,6 +1,6 @@
 - project:
     name: foreman_pipeline
     defaults: plugin
-    dbs: 'postgres sqlite3'
+    dbs: 'postgresql sqlite3'
     jobs:
       - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
I found out foreman_pipeline has [builds from other plugins](http://ci.theforeman.org/job/test_plugin_matrix/1445/) in the matrix. This was hopefully caused by specifying 'postgres' instead of 'postgresql' as one of the databases. ~~We should also be ok without defaults in test_plugin_matrix since they are supplied by test_plugin.~~