### PR TITLE
Update rubygems to match rvm default version

### DIFF
--- a/puppet/modules/slave/manifests/rvm_config.pp
+++ b/puppet/modules/slave/manifests/rvm_config.pp
@@ -1,4 +1,4 @@
-define slave::rvm_config($version, $rubygems_version = '2.4.6') {
+define slave::rvm_config($version, $rubygems_version = '2.4.8') {
   $alias = $title
 
   rvm_system_ruby { $version:


### PR DESCRIPTION
on a new install:
```
Sep 10 09:25:26 banana puppet-agent[4010]: (/Stage[main]/Slave/Slave::Rvm_config[ruby-2.2]/Exec[ruby-2.2.3/update_rubygems]/returns) executed successfully
Sep 10 09:25:42 banana puppet-agent[4010]: (/Stage[main]/Slave/Slave::Rvm_config[ruby-2.1]/Exec[ruby-2.1.5/update_rubygems]/returns) executed successfully
Sep 10 09:25:57 banana puppet-agent[4010]: (/Stage[main]/Slave/Slave::Rvm_config[ruby-2.3]/Exec[ruby-2.3.0/update_rubygems]/returns) executed success
[...]
root@banana ~ # rvm 2.1.5 rubygems 2.4.6
Installed rubygems 2.4.8 is newer than 2.4.6 provided with installed ruby, skipping installation, use --force to force installation.
```