### PR TITLE
Upgrade npm before npm install

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -24,8 +24,11 @@ while ! bundle install --without=development -j 5; do
   fi
 done
 
-# run npm install if package.json exists and we are running integration tests (which only run on postgresql)
-[ ${database} = postgresql ] && [ -e "$APP_ROOT/package.json" ] && npm install
+# we need to install node modules for integration tests (which only run on postgresql)
+if [ ${database} = postgresql -a -e "$APP_ROOT/package.json" ]; then
+  npm install npm # first upgrade to newer npm
+  $APP_ROOT/node_modules/.bin/npm install
+fi
 
 # Database environment
 (


### PR DESCRIPTION
This allows two major benefits: shrinkwrap can be used to only pin
certain dependencies rather then entire trees, and download size is
greatly reduced as the module tree is flattened to reduce duplications.