### PR TITLE
Migrate test db while testing plugins

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -3,6 +3,7 @@
 TOP_ROOT=`pwd`
 APP_ROOT=$TOP_ROOT/foreman
 PLUGIN_ROOT=$TOP_ROOT/plugin
+RAILS_ENV=test
 
 cd $APP_ROOT
 


### PR DESCRIPTION
By default rake db:create creates databases for development and test
environments and rake db:migrate migrates the development database. When
we run tests the test environment is used by default and thanks to

`config.active_record.maintain_test_schema = true`

the test db gets migrated automatically. However this somehow doesn't
satisfy the access permissions tests for plugins which fail. Running the
tests against an already migrated database solves the issue.