### PR TITLE
update rubygems version to 2.5.2

### DIFF
--- a/puppet/modules/slave/manifests/rvm_config.pp
+++ b/puppet/modules/slave/manifests/rvm_config.pp
@@ -1,4 +1,4 @@
-define slave::rvm_config($version, $rubygems_version = '2.4.8') {
+define slave::rvm_config($version, $rubygems_version = '2.5.2') {
   $alias = $title
 
   rvm_system_ruby { $version:


### PR DESCRIPTION
As RVM with Ruby 2.3 is already bringing 2.5.1 by default, the current default leads to a change at every puppet run, as a downgrade 2.5.1 -> 2.4.8 is not done.