### PR TITLE
updated ruby 2.x.x versions to current stable ones

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -283,17 +283,17 @@ class slave($github_user = undef,
         version => 'ruby-1.9.3-p392',
       }
       slave::rvm_config { 'ruby-2.0.0':
-        version => 'ruby-2.0.0-p353',
+        version => 'ruby-2.0.0-p484',
       }
     }
     slave::rvm_config { 'ruby-2.1':
       version => 'ruby-2.1.5',
     }
     slave::rvm_config { 'ruby-2.2':
-      version => 'ruby-2.2.3',
+      version => 'ruby-2.2.5',
     }
     slave::rvm_config { 'ruby-2.3':
-      version => 'ruby-2.3.0',
+      version => 'ruby-2.3.1',
     }
 
     # Cleanup log dirs


### PR DESCRIPTION
This updates ruby 2.x.x versions to current stable ones. This should also resolve https://bugs.ruby-lang.org/issues/11910 that is occurring in tests on ruby 2.3.0.