### PR TITLE
extend PATH for pbuilder

### DIFF
--- a/puppet/modules/debian/manifests/init.pp
+++ b/puppet/modules/debian/manifests/init.pp
@@ -131,6 +131,13 @@ class debian {
     }
   }
 
+  shellvar { 'extend_pbuilder_path':
+    ensure   => present,
+    target   => '/etc/pbuilderrc',
+    variable => 'PATH',
+    value    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+  }
+
   # Add freight setup
   include freight::uploader
 


### PR DESCRIPTION
otherwise the rake binstub in /usr/local/bin is not found on Debian 8 or newer