### PR TITLE
disable armhf builds on Ubuntu/trusty

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -33,7 +33,7 @@
           values:
           - debian
     execution-strategy:
-      combination-filter: '((onlyos == "all") || onlyos == os) && !(arch == "armv7" && (os == "wheezy" || os == "precise")) && !(arch == "armv8" && (os == "wheezy" || os == "precise" || os == "trusty" || os == "jessie")) && !((version == "nightly" || version == "1.13" || version == "1.12") && (os == "wheezy" || os == "precise")) && !((version == "1.11") && (os == "xenial"))'
+      combination-filter: '((onlyos == "all") || onlyos == os) && !(arch == "armv7" && (os == "wheezy" || os == "precise" || os == "trusty")) && !(arch == "armv8" && (os == "wheezy" || os == "precise" || os == "trusty" || os == "jessie")) && !((version == "nightly" || version == "1.13" || version == "1.12") && (os == "wheezy" || os == "precise")) && !((version == "1.11") && (os == "xenial"))'
     builders:
       - build_deb_coreproject
     publishers:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_dependency.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_dependency.yaml
@@ -36,7 +36,7 @@
           values:
           - debian
     execution-strategy:
-      combination-filter: '((onlyos == "all") || onlyos == os) && !(arch == "armv7" && (os == "wheezy" || os == "precise")) && !(arch == "armv8" && (os == "wheezy" || os == "precise" || os == "trusty" || os == "jessie")) && !((version == "nightly" || version == "1.13" || version == "1.12") && (os == "wheezy" || os == "precise")) && !((version == "1.11") && (os == "xenial"))'
+      combination-filter: '((onlyos == "all") || onlyos == os) && !(arch == "armv7" && (os == "wheezy" || os == "precise" || os == "trusty")) && !(arch == "armv8" && (os == "wheezy" || os == "precise" || os == "trusty" || os == "jessie")) && !((version == "nightly" || version == "1.13" || version == "1.12") && (os == "wheezy" || os == "precise")) && !((version == "1.11") && (os == "xenial"))'
     builders:
       - build_deb_dependency
     publishers:


### PR DESCRIPTION
As http://projects.theforeman.org/issues/15827 seems not to be solveable. Once this is merged, I'll open a PR to the docs and inform foreman-users.