### PR TITLE
Allow core dependency plugin testing

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -50,6 +50,8 @@ bundle exec rake db:drop db:create db:migrate
 
 ### END test_develop ###
 
+# Ensure we don't mention the gem twice in the Gemfile in case it's already mentioned there
+find Gemfile bundler.d -type f -exec sed -i "/gem ['\"]${plugin_name}['\"]/d" {} \;
 # Now let's introduce the plugin
 echo "gem '${plugin_name}', :path => '${PLUGIN_ROOT}'" >> bundler.d/Gemfile.local.rb
 


### PR DESCRIPTION
Scan first thought the Gemfile in case the plugin gem is already
mentioned somewhere, as bundler doesn't like when something is mentioned twice.

Preparation for https://github.com/theforeman/foreman/pull/3670