### PR TITLE
Update the branch we upgrade from to 1.13-stable

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop_pr_upgrade.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop_pr_upgrade.yaml
@@ -37,7 +37,7 @@
           type: user-defined
           name: old_branch
           values:
-            - 1.11-stable
+            - 1.13-stable
     builders:
       - shell: !include-raw: scripts/test/test_upgrade.sh
     publishers:


### PR DESCRIPTION
1.11 bundle install has many incompatibilities, such as:
 gettext_i18n_rails-1.8.0, nokogiri 1.7.0
which do not work with Ruby 2.0.0.