### PR TITLE
Send failed develop and stable branches to list

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_plugin.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_plugin.yaml
@@ -31,6 +31,7 @@
           block: true
     publishers:
       - ircbot_freenode
+      - email_list
 
 - defaults:
     name: plugin

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/email_list.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/email_list.yaml
@@ -1,0 +1,6 @@
+- publisher:
+    name: email_list
+    publishers:
+    - email:
+        recipients: foreman-jenkins@googlegroups.com
+        notify-every-unstable-build: false


### PR DESCRIPTION
Here is my proposal: Let's create an email list and configure Jenkins to
send failure emails for all core + plugins develop + stable branches
there. Developers can pick from there and filter what they want.

I am new to this YAML thing, I haven't tested this yet, so this needs
review and also I did not create any mailing list yet (the email there
is just a suggested name we could use).

I hope this will not include failures from PRs, that would totally ruin
the experience and that is not my intention at all.