### PR TITLE
Add name param to yum repo to make yum-cron happy

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -226,6 +226,7 @@ class slave($github_user = undef,
     yumrepo { 'isimluk-openscap':
       enabled     => 1,
       gpgcheck    => 0,
+      name        => 'isimluk-openscap',
       baseurl     => "http://copr-be.cloud.fedoraproject.org/results/isimluk/OpenSCAP/epel-${::operatingsystemmajrelease}-\$basearch/",
       includepkgs => ['openscap'],
     } ->


### PR DESCRIPTION
Hopefully prevents emails like this:

```
/etc/cron.hourly/0yum-hourly.cron:

Repository 'isimluk-openscap' is missing name in configuration, using id
```