### PR TITLE
Revert "don't install optional npm dependencies"

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -27,7 +27,7 @@ done
 # we need to install node modules for integration tests (which only run on postgresql)
 if [ ${database} = postgresql -a -e "$APP_ROOT/package.json" ]; then
   npm install npm # first upgrade to newer npm
-  $APP_ROOT/node_modules/.bin/npm install --no-optional
+  $APP_ROOT/node_modules/.bin/npm install
 fi
 
 # Database environment

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -35,7 +35,7 @@ done
 # we need to install node modules for integration tests
 if [ -e "$APP_ROOT/package.json" ]; then
   npm install npm # first upgrade to newer npm
-  $APP_ROOT/node_modules/.bin/npm install --no-optional
+  $APP_ROOT/node_modules/.bin/npm install
 fi
 
 # Database environment


### PR DESCRIPTION
Optional dependencies includes phantomjs for integration tests, which
is used for CI testing, but not for general production installation.

This reverts commit 0c1def1108574717f280621f6fbba7a7f1311065.