### PR TITLE
use saz-sudo 3.0.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = git://github.com/puppetlabs/puppetlabs-stdlib.git
 [submodule "puppet/modules/sudo"]
 	path = puppet/modules/sudo
-	url = https://github.com/treydock/puppet-sudo-old.git
+	url = https://github.com/saz/puppet-sudo.git
 [submodule "puppet/modules/foreman_proxy"]
 	path = puppet/modules/foreman_proxy
 	url = git://github.com/theforeman/puppet-foreman_proxy.git

--- a/puppet/Rakefile
+++ b/puppet/Rakefile
@@ -1,4 +1,1 @@
 require 'puppet-syntax/tasks/puppet-syntax'
-
-# sudo module does not follow auto-loading, needs updating or replacing
-PuppetSyntax.exclude_paths = ['modules/sudo/manifests/init.pp']

--- a/puppet/modules/quassel/manifests/init.pp
+++ b/puppet/modules/quassel/manifests/init.pp
@@ -36,9 +36,8 @@ class quassel (
   }
 
   include sudo
-  sudo::directive { "sudo-puppet-quassel":
-    ensure    => present,
-    content   => "%quassel ALL=NOPASSWD:/usr/bin/quasselcore *\n",
+  sudo::conf { 'sudo-puppet-quassel':
+    content => '%quassel ALL=NOPASSWD:/usr/bin/quasselcore *',
   }
 
   if $users == 'undef' {

--- a/puppet/modules/users/manifests/account.pp
+++ b/puppet/modules/users/manifests/account.pp
@@ -43,9 +43,8 @@ define users::account(
     require => File["/home/$name/.ssh"]
   }
 
-  sudo::directive { "sudo-puppet-${name}":
-    ensure    => present,
-    content   => "$name ALL=(ALL) ALL\n",
+  sudo::conf { "sudo-puppet-${name}":
+    content => "$name ALL=(ALL) ALL",
   }
 
 }

--- a/puppet/modules/users/manifests/slave.pp
+++ b/puppet/modules/users/manifests/slave.pp
@@ -39,9 +39,8 @@ class users::slave {
     source  => "puppet:///modules/users/jenkins-ssh_config"
   }
 
-  sudo::directive { "puppet-jenkins":
-    ensure => present,
-    content => "jenkins ALL=NOPASSWD: ALL\n"
+  sudo::conf { 'puppet-jenkins':
+    content => 'jenkins ALL=NOPASSWD: ALL',
   }
 
 }


### PR DESCRIPTION
I'd say let's try this... the sudo rules for users look good.

Diff of /etc/sudoers on a EL6 machine:

```diff
--- /etc/sudoers	2017-06-23 21:01:32.164000030 +0200
+++ /tmp/puppet-file20170623-11702-1amq4ie-0	2017-06-23 21:03:29.180000030 +0200
@@ -53,7 +53,13 @@
 # Disable "ssh hostname sudo <cmd>", because it will show the password in clear. 
 #         You have to run "ssh -t hostname sudo <cmd>".
 #
-## Defaults    requiretty
+Defaults    requiretty
+
+#
+# Refuse to run if unable to disable echo on the tty. This setting should also be
+# changed in order to be able to use sudo without a tty. See requiretty above.
+#
+Defaults   !visiblepw
 
 #
 # Preserving HOME has security implications since many programs
@@ -74,8 +80,7 @@
 #
 # Defaults   env_keep += "HOME"
 
-# Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
-
+Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
 
 ## Next comes the main part: which users can run what software on 
 ## which machines (the sudoers file can be shared between multiple
@@ -94,7 +99,7 @@
 # %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
 
 ## Allows people in group wheel to run all commands
-%wheel	ALL=(ALL)	ALL
+# %wheel	ALL=(ALL)	ALL
 
 ## Same thing without a password
 # %wheel	ALL=(ALL)	NOPASSWD: ALL
@@ -106,4 +111,5 @@
 ## Allows members of the users group to shutdown this system
 # %users  localhost=/sbin/shutdown -h now
 
+## Read drop-in files from /etc/sudoers.d (the # here does not mean a comment)
 #includedir /etc/sudoers.d
```