### PR TITLE
Add pipeline based Jenkins job for Katello PRs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/generate_jobs.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/generate_jobs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jenkins-jobs -l debug test -r . -o /tmp/jobs
+jenkins-jobs -l debug test -r -o /tmp/jobs yaml "$@"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
@@ -1,0 +1,63 @@
+def databaseFile (id) {
+    writeFile(file: 'config/database.yml', text: """
+test:
+  adapter: postgresql
+  database: ${id}-test
+  username: foreman
+  password: foreman
+  host: localhost
+  template: template0
+
+development:
+  adapter: postgresql
+  database: ${id}-development
+  username: foreman
+  password: foreman
+  host: localhost
+  template: template0
+
+production:
+  adapter: postgresql
+  database: ${id}-development
+  username: foreman
+  password: foreman
+  host: localhost
+  template: template0
+""")
+
+}
+
+def addGem() {
+    writeFile(text: "gemspec :path => '../', :development_group => :dev", file: 'bundler.d/Gemfile.local.rb')
+}
+
+def addSettings(settings) {
+    sh "cp config/settings.yaml.example config/settings.yaml"
+
+    if (settings['locations']) {
+        sh "sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml"
+    }
+
+    if (settings['organizations']) {
+        sh "sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml"
+    }
+}
+
+def configureDatabase(ruby) {
+    withRVM(['bundle update'], ruby)
+    withRVM(['bundle exec rake db:drop -q || true'], ruby)
+    withRVM(['bundle exec rake db:create -q'], ruby)
+    withRVM(['bundle exec rake db:migrate -q'], ruby)
+}
+
+def cleanup() {
+    try {
+
+        withRVM(['bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true'])
+
+    } finally {
+
+        cleanupRVM('', ruby)
+
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -9,8 +9,14 @@ def gemset(name) {
     base_name
 }
 
-def cleanup_rvm(name = '') {
-    withRVM(["rvm gemset delete ${gemset(name)} --force"])
+def configureRVM(ruby = '2.0') {
+    withRVM(['rvm gemset empty --force'], ruby)
+    withRVM(['gem update --no-ri --no-rdoc'], ruby)
+    withRVM(['gem install bundler'], ruby)
+}
+
+def cleanupRVM(name = '', ruby = '2.0') {
+    withRVM(["rvm gemset delete ${gemset(name)} --force"], ruby)
 }
 
 def withRVM(commands, ruby = '2.0', name = '') {
@@ -20,7 +26,6 @@ def withRVM(commands, ruby = '2.0', name = '') {
 
     sh """#!/bin/bash -l
         rvm use ruby-${ruby}@${gemset(name)} --create
-        gem install bundler
         ${commands}
     """
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -1,0 +1,141 @@
+def ruby = '2.4'
+def katello_versions = [
+    'master': 'develop',
+    'KATELLO-3.6': '1.17-stable',
+    'KATELLO-3.5': '1.16-stable'
+]
+
+pipeline {
+    agent { label 'fast' }
+
+    stages {
+        stage('Setup Git Repos') {
+            steps {
+               checkout changelog: true, poll: false, scm: [
+                   $class: 'GitSCM',
+                   branches: [[name: '${ghprbActualCommit}']],
+                   doGenerateSubmoduleConfigurations: false,
+                   extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'default', mergeTarget: '${ghprbTargetBranch}']]],
+                   userRemoteConfigs: [
+                       [refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*', url: 'https://github.com/katello/katello']
+                   ]
+               ]
+
+                dir('foreman') {
+                    git url: "https://github.com/theforeman/foreman", branch: katello_versions[ghprbTargetBranch]
+                }
+            }
+        }
+        stage("Setup RVM") {
+            steps {
+
+                configureRVM(ruby)
+
+            }
+        }
+        stage('Configure Environment') {
+            steps {
+
+                dir('foreman') {
+                    addSettings([
+                        organizations: true,
+                        locations: true
+                    ])
+                    addGem()
+                    databaseFile(gemset())
+                }
+
+            }
+        }
+        stage('Configure Database') {
+            steps {
+
+                dir('foreman') {
+                    configureDatabase(ruby)
+                }
+
+            }
+        }
+        stage('Run Tests') {
+            parallel {
+                stage('tests') {
+                    steps {
+                        dir('foreman') {
+                            withRVM(['bundle exec rake jenkins:katello TESTOPTS="-v"'], ruby)
+                        }
+                    }
+                }
+                stage('rubocop') {
+                    steps {
+                        dir('foreman') {
+                            withRVM(['bundle exec rake katello:rubocop TESTOPTS="-v" --trace'], ruby)
+                        }
+                    }
+                }
+                stage('react-ui') {
+                    when {
+                        expression { fileExists('package.json') }
+                    }
+                    steps {
+                        sh 'npm install'
+                        sh 'npm test'
+                    }
+                }
+                stage('angular-ui') {
+                    steps {
+                        dir('foreman') {
+                            withRVM(['bundle show bastion > bastion-version'], ruby)
+
+                            script {
+                                bastion_install = readFile('bastion-version')
+                                bastion_version = bastion_install.split('bastion-')[1]
+                                echo bastion_install
+                                echo bastion_version
+                            }
+                        }
+
+                        sh "cp -rf \$(cat foreman/bastion-version) engines/bastion_katello/bastion-${bastion_version}"
+
+                        dir('engines/bastion_katello') {
+                            sh "npm install npm"
+                            sh "node_modules/.bin/npm install bastion-${bastion_version}"
+                            sh "grunt ci"
+                        }
+                    }
+                }
+                stage('assets-precompile') {
+                    steps {
+                        dir('foreman') {
+                            withRVM(['bundle exec rake plugin:assets:precompile[katello] RAILS_ENV=production --trace'], ruby)
+                        }
+                    }
+                }
+            }
+        }
+        stage('Test db:seed') {
+            steps {
+
+                dir('foreman') {
+
+                    withRVM(['bundle exec rake db:drop'], ruby)
+                    withRVM(['bundle exec rake db:create'], ruby)
+                    withRVM(['bundle exec rake db:migrate'], ruby)
+                    withRVM(['bundle exec rake db:seed'], ruby)
+
+                }
+
+            }
+        }
+    }
+
+    post {
+        always {
+            dir('foreman') {
+                archiveArtifacts artifacts: "Gemfile.lock"
+                junit keepLongStdio: true, testResults: 'jenkins/reports/unit/*.xml'
+                cleanup()
+            }
+            deleteDir()
+        }
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/katello-pr-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/katello-pr-test.yaml
@@ -1,0 +1,18 @@
+- job:
+    name: katello-pr-test
+    project-type: workflow
+    concurrent: true
+    logrotate:
+      daysToKeep: 30
+      numToKeep: -1
+    properties:
+      - github:
+          url: https://github.com/Katello/katello
+    triggers:
+      - github_pr:
+          context: 'katello'
+    dsl:
+      !include-raw:
+        - pipelines/test/testKatello.groovy
+        - pipelines/lib/rvm.groovy
+        - pipelines/lib/foreman.groovy


### PR DESCRIPTION
This is an attempt at re-writing test-katello as a pipeline using parallelism. The job can be browsed at [1]. This still needs the JS tests added to it. I wanted to open this up to get some thought around this approach as compared to a more linear approach. @mmoll @egolov  If you wouldn't mind lending some thoughts.


[1] http://ci.theforeman.org/blue/organizations/jenkins/test-katello/activity