### PR TITLE
Allow running Jenkins over HTTPS

### DIFF
--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -11,11 +11,7 @@
 class web($stable = "1.15", $latest = "1.16", $next = "1.17", $htpasswds = {}, $https = false) {
   include apache
   include rsync::server
-
-  class { 'letsencrypt':
-    email          => 'foreman-infra-notifications@googlegroups.com',
-    configure_epel => false,
-  }
+  include web::letsencypt
 
   letsencrypt::certonly { 'theforeman.org':
     plugin        => 'webroot',
@@ -39,14 +35,6 @@ class web($stable = "1.15", $latest = "1.16", $next = "1.17", $htpasswds = {}, $
       '/var/www/vhosts/web/htdocs',
       '/var/www/vhosts/yum/htdocs',
     ],
-  }
-
-  cron { 'letsencrypt_renew':
-    command => '/usr/bin/certbot renew --renew-hook "/sbin/service httpd reload"',
-    user    => root,
-    weekday => '6',
-    hour    => '3',
-    minute  => '27'
   }
 
   if $selinux {

--- a/puppet/modules/web/manifests/jenkins.pp
+++ b/puppet/modules/web/manifests/jenkins.pp
@@ -1,12 +1,19 @@
-class web::jenkins($hostname = 'ci.theforeman.org') {
+class web::jenkins(
+  $hostname = 'ci.theforeman.org',
+  $webroot = '/var/www/vhosts/jenkins/htdocs',
+) {
   include apache
-  include apache::mod::proxy
-  include apache::mod::proxy_http
+
+  $proxy_pass = {
+    'path'     => '/',
+    'url'      => 'http://localhost:8080/',
+    'keywords' => ['nocanon'],
+  }
 
   apache::vhost { 'jenkins':
-    port            => '80',
-    servername      => $hostname,
-    docroot         => '/var/www/vhosts/jenkins/htdocs',
-    custom_fragment => template('web/jenkins.conf.erb'),
+    port       => '80',
+    servername => $hostname,
+    docroot    => $webroot,
+    proxy_pass => $proxy_pass,
   }
 }

--- a/puppet/modules/web/manifests/letsencrypt.pp
+++ b/puppet/modules/web/manifests/letsencrypt.pp
@@ -1,0 +1,16 @@
+class web::letsencrypt(
+  $email = 'foreman-infra-notifications@googlegroups.com',
+) {
+  class { '::letsencrypt':
+    email          => $email,
+    configure_epel => false,
+  }
+
+  cron { 'letsencrypt_renew':
+    command => '/usr/bin/certbot renew --renew-hook "/sbin/service httpd reload"',
+    user    => 'root',
+    weekday => '6',
+    hour    => '3',
+    minute  => '27',
+  }
+}

--- a/puppet/modules/web/templates/jenkins.conf.erb
+++ b/puppet/modules/web/templates/jenkins.conf.erb
@@ -1,8 +1,0 @@
-ProxyRequests Off
-<Proxy *>
-  Order deny,allow
-  Allow from all
-</Proxy>
-ProxyPreserveHost on
-ProxyPass / http://localhost:8080/ nocanon
-ProxyPassReverse / http://localhost:8080/


### PR DESCRIPTION
Things to verify:

* [ ] Doesn't break existing web nodes (refactor should be safe)
* [ ] Doesn't break jenkins forwarding (left out the ```<Proxy *>```, not sure if that's needed)
* [ ] Letsencrypts .well-known directory might be forwarded to Jenkins as well causing cert requests to fail
* [ ] Enable SSL works and Jenkins is configured to work with it
* [ ] Do we want to disable plain text and move everything over?