### PR TITLE
Set the docroot owner for the jenkins vhost

### DIFF
--- a/puppet/modules/web/manifests/jenkins.pp
+++ b/puppet/modules/web/manifests/jenkins.pp
@@ -21,23 +21,27 @@ class web::jenkins(
   }
 
   apache::vhost { 'jenkins':
-    port       => '80',
-    servername => $hostname,
-    docroot    => $webroot,
-    proxy_pass => $proxy_pass,
+    port          => '80',
+    servername    => $hostname,
+    docroot       => $webroot,
+    docroot_owner => $::apache::user,
+    docroot_group => $::apache::group,
+    proxy_pass    => $proxy_pass,
   }
 
   if $https {
     apache::vhost { 'jenkins':
-      port       => 443,
-      servername => $hostname,
-      docroot    => $webroot,
-      proxy_pass => $proxy_pass,
-      ssl        => true,
-      ssl_cert   => "/etc/letsencrypt/live/${hostname}/fullchain.pem",
-      ssl_chain  => "/etc/letsencrypt/live/${hostname}/chain.pem",
-      ssl_key    => "/etc/letsencrypt/live/${hostname}/privkey.pem",
-      require    => Letsencrypt::Certonly[$hostname],
+      port          => 443,
+      servername    => $hostname,
+      docroot       => $webroot,
+      docroot_owner => $::apache::user,
+      docroot_group => $::apache::group,
+      proxy_pass    => $proxy_pass,
+      ssl           => true,
+      ssl_cert      => "/etc/letsencrypt/live/${hostname}/fullchain.pem",
+      ssl_chain     => "/etc/letsencrypt/live/${hostname}/chain.pem",
+      ssl_key       => "/etc/letsencrypt/live/${hostname}/privkey.pem",
+      require       => Letsencrypt::Certonly[$hostname],
     }
   }
 }


### PR DESCRIPTION
Since it's set to root:root 750 by default this allows access to the .well-known directory which makes letsencrypt work.