### PR TITLE
remove echo from filter_apache_stats

### DIFF
--- a/puppet/modules/web/files/filter_apache_stats.sh
+++ b/puppet/modules/web/files/filter_apache_stats.sh
@@ -18,27 +18,23 @@
 # is possible that a logrotation has happened overnight, the last *two* files
 # are parsed. Files are datestamped with a one-week cleanup.
 
-debs=`ls -1rt /var/log/httpd/deb_access.log*|tail -n2`
-yums=`ls -1rt /var/log/httpd/yum_access.log*|tail -n2`
-date=`date '+%Y%m%d'`
+debs=$(ls -1rt /var/log/httpd/deb_access.log*|tail -n2)
+yums=$(ls -1rt /var/log/httpd/yum_access.log*|tail -n2)
+date=$(date '+%Y%m%d')
 ldir='/var/cache/parsed_apache_logs'
 
 mkdir -p $ldir
 
-echo -n "Parsing:"
-echo $debs
-grep "\s200\s" $debs \
+grep "\s200\s" "$debs" \
   | grep "\"GET" \
   | grep "\.deb\s" \
   > ${ldir}/deb_downloads.${date}.log
 
-echo -n "Parsing:"
-echo $yums
-grep "\s200\s" $yums \
+grep "\s200\s" "$yums" \
   | grep "\"GET" \
   | grep "\.rpm\s" \
   | grep -v "\/source\/" \
-  | egrep -v "/(releases|nightly)/.*(tfm|rubygem)" \
+  | grep -E -v "/(releases|nightly)/.*(tfm|rubygem)" \
   > ${ldir}/yum_downloads.${date}.log
 
 # Clean up old backups over a week old


### PR DESCRIPTION
This prevents cron mails from being sent every day.
While here, fix some shellcheck warnings.