### PR TITLE
Revert web::base for duplicate apache resource

### DIFF
--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -9,8 +9,9 @@
 #          certs have to exist, so keep SSL vhosts disabled until the certs are present via the HTTP
 #          vhost and only then enable the SSL vhosts.
 class web($stable = "1.15", $latest = "1.16", $next = "1.17", $htpasswds = {}, $https = false) {
-  include web::base
+  include apache
   include rsync::server
+  include web::letsencrypt
 
   letsencrypt::certonly { 'theforeman.org':
     plugin        => 'webroot',


### PR DESCRIPTION
This results in a duplicate resource and I don't exactly know why yet.
Revert it for now.