### PR TITLE
Add webpack build step to test_develop

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -27,7 +27,8 @@ done
 # we need to install node modules for integration tests (which only run on postgresql)
 if [ ${database} = postgresql -a -e "$APP_ROOT/package.json" ]; then
   npm install npm@'<5.0.0' # first upgrade to newer npm
-  $APP_ROOT/node_modules/.bin/npm install
+  $APP_ROOT/node_modules/.bin/npm install --no-optional --global-style true
+  ./node_modules/webpack/bin/webpack.js --bail --config config/webpack.config.js
 fi
 
 # Database environment


### PR DESCRIPTION
Adding this check ensures that the RPM build step that has caused
failing builds multiple times is tested before code goes into the
repository.