### PR TITLE
Fix redmine backup script

### DIFF
--- a/puppet/modules/redmine/manifests/init.pp
+++ b/puppet/modules/redmine/manifests/init.pp
@@ -163,7 +163,7 @@ class redmine (
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
-    content => template('redmine/postgresql_backup.sh'),
+    content => template('redmine/postgresql_backup.sh.erb'),
   }
 
   file { '/usr/local/bin/redmine_repos.sh':

--- a/puppet/modules/redmine/templates/postgresql_backup.sh
+++ b/puppet/modules/redmine/templates/postgresql_backup.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Backs up the OpenShift PostgreSQL database for this application
- 
-FILENAME="/usr/share/redmine_data/redmine.backup.sql.gz"
-
-cd /tmp
-sudo -u postgres pg_dump <%= @db_name %> | gzip > $FILENAME

--- a/puppet/modules/redmine/templates/postgresql_backup.sh.erb
+++ b/puppet/modules/redmine/templates/postgresql_backup.sh.erb
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Backs up the OpenShift PostgreSQL database for this application
+
+FILENAME="<%= @data_dir %>/redmine.backup.sql.gz"
+DBNAME="<%= @db_name %>"
+
+cd /tmp
+sudo -u postgres pg_dump $DBNAME | gzip > $FILENAME


### PR DESCRIPTION
This was still dumping the database to the old location. It also adds the .erb extension and introduces the DBNAME variable