### PR TITLE
Hide verbose rvm output in jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/deploy_katello_site.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/deploy_katello_site.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -xe
 
-# Build the site on the slave 
+echo "Setting up RVM environment."
+set +x
+# Build the site on the slave
 ruby=2.0.0
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
@@ -8,7 +10,8 @@ ruby=2.0.0
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
-#gem update --no-ri --no-rdoc
+set -x
+
 gem install bundler --no-ri --no-rdoc
 
 # Reset environment

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/deploy_web.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/deploy_web.sh
@@ -1,14 +1,17 @@
 #!/bin/bash -xe
 
-# Build the site on the slave 
+# Build the site on the slave
 
+echo "Setting up RVM environment."
 # RVM Ruby environment
+set +x
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
-#gem update --no-ri --no-rdoc
+set -x
+
 gem install bundler --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent
@@ -21,7 +24,7 @@ while ! bundle install -j 5; do
 done
 
 # compile site on slave
-bundle exec jekyll build 
+bundle exec jekyll build
 
 # Copy the site to the web node
 # Dependencies

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/gemset_cleanup.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/gemset_cleanup.sh
@@ -8,10 +8,13 @@ fi
 # Clean npm modules
 [ -d node_modules ] && rm -rf node_modules/
 
+echo "Setting up RVM environment."
+set +x
 # Clean gemset and database
 . /etc/profile.d/rvm.sh
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset}
+set -x
 
 # Env var works around Rails issue #28001 if DB migrations fail
 bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/pkg_generate_source.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/pkg_generate_source.sh
@@ -1,11 +1,15 @@
 #!/bin/bash -xe
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
+set -x
+
 gem install bundler --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/proxy.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/proxy.sh
@@ -5,12 +5,16 @@ APP_ROOT=`pwd`
 # setup basic settings file
 cp $APP_ROOT/config/settings.yml.example $APP_ROOT/config/settings.yml
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
+set -x
+
 gem install bundler --no-ri --no-rdoc
 
 # Puppet environment

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -6,13 +6,16 @@ APP_ROOT=`pwd`
 sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
 sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
-#gem update --no-ri --no-rdoc
+set -x
+
 gem install bundler --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman.sh
@@ -1,11 +1,15 @@
 #!/bin/bash -ex
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
+set -x
+
 gem update --no-ri --no-rdoc
 gem install bundler --no-ri --no-rdoc
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
@@ -31,12 +31,16 @@ mkdir config/settings.plugins.d
 sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
 sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
+set -x
+
 gem update --no-ri --no-rdoc
 gem install bundler --no-ri --no-rdoc
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -13,13 +13,16 @@ cd $APP_ROOT
 sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
 sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
-#gem update --no-ri --no-rdoc
+
+set -x
 gem install bundler --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
@@ -8,13 +8,16 @@ APP_ROOT=`pwd`
 sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
 sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
 
+echo "Setting up RVM environment."
+set +x
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh
 # Use a gemset unique to each executor to enable parallel builds
 gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
-#gem update --no-ri --no-rdoc
+set -x
+
 gem install bundler --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent


### PR DESCRIPTION
Per a conversation on IRC with @timogoebel this would hide the overly verbose RVM output.