### PR TITLE
use `popd` instead of `popd <dir>`

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/plugin_pr_checkout.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/plugin_pr_checkout.sh
@@ -8,4 +8,4 @@ if [ -n "${pr_git_url}" ]; then
   git merge pr/${pr_git_ref}
 fi
 
-popd plugin
+popd


### PR DESCRIPTION
`popd <dir>` is not a thing [1] and produces errors on modern bash
(tested on 4.3 and 4.4):

    popd fff
    bash: popd: fff: invalid argument
    popd: usage: popd [-n] [+N | -N]

and even on older (4.2) bash, this would not produce what we expect:

    # rpm -q bash
    bash-4.2.46-29.el7_4.x86_64
    # pwd
    /tmp
    # mkdir foo && pushd foo
    /tmp/foo /tmp
    # pwd
    /tmp/foo
    # popd foo
    /tmp/foo
    # pwd
    /tmp/foo

[1] https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html