### PR TITLE
Remove f24 builds

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_push_rpm.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_push_rpm.yaml
@@ -20,4 +20,3 @@
           name: os
           values:
           - el7
-          - f24

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
@@ -24,7 +24,6 @@
           name: os
           values:
           - el7
-          - f24
           - jessie
           - stretch
           - trusty

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/systest_foreman_puppet_pc1.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/systest_foreman_puppet_pc1.yaml
@@ -17,7 +17,6 @@
           name: os
           values:
           - el7
-          - f24
           # - stretch  # not available yet
           # - xenial  # https://tickets.puppetlabs.com/browse/SERVER-17
     publishers:


### PR DESCRIPTION
In release_test.yaml it was already a dummy since the combination filter no longer allowed it. In the others I think it's no longer needed.