### PR TITLE
Enable cleanup of old user accounts

### DIFF
--- a/puppet/modules/users/manifests/account.pp
+++ b/puppet/modules/users/manifests/account.pp
@@ -36,6 +36,11 @@ define users::account(
       group   => $name,
       mode    => '0600',
     }
+  } elsif $ensure == 'absent' {
+    # Allow to revoke users access for cleanup
+    file { "${homedir}/.ssh/authorized_keys":
+      ensure  => absent,
+    }
   }
 
   sudo::conf { "sudo-puppet-${name}":


### PR DESCRIPTION
We don't actually have a way to remove old keys (although we can stop deploying them by settting ensure to something else, it's a pain to remove them by hand).