### PR TITLE
Install google-chrome in slaves

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -215,7 +215,7 @@ class slave (
       ensure => directory,
       owner  => 'jenkins',
       group  => 'jenkins',
-      mode    => '0775',
+      mode   => '0775',
     }
 
     # Cleanup temporary dir
@@ -225,6 +225,23 @@ class slave (
       group   => 'root',
       mode    => '0755',
       content => "#!/bin/sh\nfind ~jenkins/tmp -maxdepth 1 -name 'npm-*' -type d -mtime +1 -exec rm -rf {} +\n",
+    }
+  }
+
+  # Needed to test with headless chrome and Selenium
+  if $::osfamily == 'RedHat' {
+    yumrepo { 'google-chrome':
+      name     => 'google-chrome - \$basearch',
+      ensure   => present,
+      baseurl  => 'http://dl.google.com/linux/chrome/rpm/stable/\$basearch',
+      enabled  => '1',
+      gpgcheck => '1',
+      gpgkey   => 'https://dl-ssl.google.com/linux/linux_signing_key.pub',
+      before   => Package['google-chrome-stable'],
+    }
+
+    package { 'google-chrome-stable':
+      ensure => latest,
     }
   }
 


### PR DESCRIPTION
In order to use chrome headless with Selenium, and get rid of phantomjs.
For the moment, both can be installed to test https://github.com/theforeman/foreman/pull/4987
When that PR is merged and we no longer need phantomjs and firefox, 
we can remove them on another PR.