### PR TITLE
Revert "Enable cleanup of old user accounts"

### DIFF
--- a/puppet/modules/users/manifests/account.pp
+++ b/puppet/modules/users/manifests/account.pp
@@ -36,11 +36,6 @@ define users::account(
       group   => $name,
       mode    => '0600',
     }
-  } elsif $ensure == 'absent' {
-    # Allow to revoke users access for cleanup
-    file { "${homedir}/.ssh/authorized_keys":
-      ensure  => absent,
-    }
   }
 
   sudo::conf { "sudo-puppet-${name}":


### PR DESCRIPTION
This reverts commit 7c4e69995f9207916d25109e79a3fd82d88cabcd.

The previous code had managehome => true so the homedir is already
cleaned up.