### PR TITLE
only list jessie, stretch, trusty and xenial

### DIFF
--- a/puppet/modules/freight/files/deb-HEADER.html
+++ b/puppet/modules/freight/files/deb-HEADER.html
@@ -9,24 +9,21 @@
 
 <p>Currently we have</p>
 
-<pre>deb http://deb.theforeman.org/ wheezy stable
-deb http://deb.theforeman.org/ jessie stable
+<pre>deb http://deb.theforeman.org/ jessie stable
 deb http://deb.theforeman.org/ stretch stable
 deb http://deb.theforeman.org/ trusty stable
-deb http://deb.theforeman.org/ precise stable
-deb http://deb.theforeman.org/ wheezy rc
-deb http://deb.theforeman.org/ jessie rc
-deb http://deb.theforeman.org/ stretch rc
-deb http://deb.theforeman.org/ trusty rc
-deb http://deb.theforeman.org/ precise rc
-deb http://deb.theforeman.org/ wheezy nightly
+deb http://deb.theforeman.org/ xenial stable
+deb http://deb.theforeman.org/ jessie &lt;version&gt;
+deb http://deb.theforeman.org/ stretch &lt;version&gt;
+deb http://deb.theforeman.org/ trusty &lt;version&gt;
+deb http://deb.theforeman.org/ xenial &lt;version&gt;
 deb http://deb.theforeman.org/ jessie nightly
 deb http://deb.theforeman.org/ stretch nightly
 deb http://deb.theforeman.org/ trusty nightly
-deb http://deb.theforeman.org/ precise nightly
+deb http://deb.theforeman.org/ xenial nightly
 
 deb http://deb.theforeman.org/ plugins stable
-deb http://deb.theforeman.org/ plugins rc
+deb http://deb.theforeman.org/ plugins &lt;version&gt;
 deb http://deb.theforeman.org/ plugins nightly</pre>
 
 <p>This repo is also available over rsync at <code>rsync://rsync.theforeman.org/deb</code>.</p>


### PR DESCRIPTION
all other releases have way too outdated foreman releases

also replace `rc` with `<version>` because we don't really have an rc pocket