### PR TITLE
Fix google-chrome yumrepo

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -235,9 +235,9 @@ class slave (
   # Needed to test with headless chrome and Selenium
   if $::osfamily == 'RedHat' {
     yumrepo { 'google-chrome':
-      name     => 'google-chrome - \$basearch',
       ensure   => present,
-      baseurl  => 'http://dl.google.com/linux/chrome/rpm/stable/\$basearch',
+      name     => 'google-chrome - $basearch',
+      baseurl  => 'http://dl.google.com/linux/chrome/rpm/stable/$basearch',
       enabled  => '1',
       gpgcheck => '1',
       gpgkey   => 'https://dl-ssl.google.com/linux/linux_signing_key.pub',


### PR DESCRIPTION
Currently fails with:

Failed to apply catalog: Parameter baseurl failed on Yumrepo[google-chrome]: Validate method failed for class baseurl: bad URI(is not URI?): http://dl.google.com/linux/chrome/rpm/stable/\$basearch at /etc/puppetlabs/code/environments/production/modules/slave/manifests/init.pp:237

Also fixes a puppet-lint check that ensure should be first.