### PR TITLE
Handle unknown releasers in packaging_build_rpm.sh

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_build_rpm.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_build_rpm.sh
@@ -5,6 +5,18 @@ if [ -n "${pr_git_url}" -a ${scratch} != true ]; then
   exit 1
 fi
 
+if ! tito release -l | grep -q "$releaser" ; then
+	if [[ $releaser == koji-katello* ]] ; then
+		# Starting 1.17 the katello packaging repo was merged. Before
+		# that we can safely ignore this.
+		echo "Releaser $releaser is not configured. Skipping"
+		exit 0
+	else
+		echo "ERROR: Releaser $releaser is not configured"
+		exit 1
+	fi
+fi
+
 git-annex init
 ./setup_sources.sh $project
 


### PR DESCRIPTION
There were 3 solutions I could think of:

Preventing the run in the first place by changing packaging_test_pull_request would be nice, but that job is not managed by JJB so was IMHO somewhat risky. It'd save more resources but this job fails very fast so should be light enough.

This made the most sense since it produces an understandable and short error message if it's somehow misconfigured. We can later always exit 1 when all known releasers are in all supported branches.

We could also add the releasers to the 1.15 and 1.16 branches.

In the end we might up using all 3.