### PR TITLE
Install chromedriver in slaves

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -119,3 +119,6 @@
 [submodule "puppet/modules/datacat"]
 	path = puppet/modules/datacat
 	url = https://github.com/richardc/puppet-datacat.git
+[submodule "puppet/modules/chromedriver"]
+	path = puppet/modules/chromedriver
+	url = https://github.com/rfletcher/puppet-chromedriver

--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -251,6 +251,10 @@ class slave (
     package { 'google-chrome-stable':
       ensure => latest,
     }
+
+    class { 'chromedriver':
+      ensure => latest,
+    }
   }
 
   # needed by katello gem dependency qpid-messaging


### PR DESCRIPTION
Precedes https://github.com/theforeman/foreman/pull/4987, tests are failing with 

```
Selenium::WebDriver::Error::WebDriverError:  Unable to find chromedriver. Please download the server from http://chromedriver.storage.googleapis.com/index.html and place it somewhere on your PATH. More info at https://github.com/SeleniumHQ/selenium/wiki/ChromeDriver....
```