### PR TITLE
use npm 5.x

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -29,7 +29,7 @@ done
 
 # we need to install node modules for integration tests (which only run on postgresql)
 if [ ${database} = postgresql -a -e "$APP_ROOT/package.json" ]; then
-  npm install npm@'<5.0.0' # first upgrade to newer npm
+  npm install npm@'<6.0.0' # first upgrade to newer npm
   $APP_ROOT/node_modules/.bin/npm install --global-style true
   ./node_modules/webpack/bin/webpack.js --bail --config config/webpack.config.js
 fi

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -37,7 +37,7 @@ done
 
 # we need to install node modules for integration tests
 if [ -e "$APP_ROOT/package.json" ]; then
-  npm install npm@'<5.0.0' # first upgrade to newer npm
+  npm install npm@'<6.0.0' # first upgrade to newer npm
   $APP_ROOT/node_modules/.bin/npm install
 fi
 


### PR DESCRIPTION
Since 1696b3087 in foreman-packaging npm 5.x is used for DEB builds and it's working fine.