### PR TITLE
Add --trace to rake tasks

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/proxy.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/proxy.sh
@@ -21,4 +21,4 @@ gem install bundler --no-ri --no-rdoc
 sed -i "/^\s*gem.*puppet/ s/\$/, '~> $puppet'/" $APP_ROOT/bundler.d/puppet.rb
 
 bundle install --without=development
-bundle exec rake pkg:generate_source jenkins:unit
+bundle exec rake pkg:generate_source jenkins:unit --trace

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -42,12 +42,12 @@ fi
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
-bundle exec rake db:drop db:create db:migrate
+bundle exec rake db:drop db:create db:migrate --trace
 
 tasks="pkg:generate_source jenkins:unit"
 [ ${database} = postgresql ] && tasks="$tasks jenkins:integration"
-bundle exec rake $tasks TESTOPTS="-v"
+bundle exec rake $tasks TESTOPTS="-v" --trace
 
 # Run the DB seeds to verify they work
-bundle exec rake db:drop db:create db:migrate
-bundle exec rake db:seed
+bundle exec rake db:drop db:create db:migrate --trace
+bundle exec rake db:seed --trace

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_foreman_virt_who_configure.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_foreman_virt_who_configure.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-bundle exec rake test:foreman_virt_who_configure TESTOPTS="-v"
+bundle exec rake test:foreman_virt_who_configure TESTOPTS="-v" --trace

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman.sh
@@ -25,4 +25,4 @@ while ! bundle install --without=development; do
   fi
 done
 
-bundle exec rake pkg:generate_source ci:setup:minitest test TESTOPTS="-v"
+bundle exec rake pkg:generate_source ci:setup:minitest test TESTOPTS="-v" --trace

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
@@ -65,22 +65,22 @@ done
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
-bundle exec rake db:create
+bundle exec rake db:create --trace
 ### END test_develop ###
 
 # Now let's add the plugin migrations
-bundle exec rake db:migrate
+bundle exec rake db:migrate --trace
 
 # Katello-specific tests
-bundle exec rake jenkins:katello TESTOPTS="-v"
+bundle exec rake jenkins:katello TESTOPTS="-v" --trace
 
 # Run the DB seeds to verify they work
 # Don't run DB seeds if the version of katello is less than 3.1
 VERSION=$(grep -Po "(\d+\.)+\d+" ${PLUGIN_ROOT}/lib/katello/version.rb)
 
 if [ $(echo ${VERSION}$'\n3.1.0' | sort --version-sort --reverse | head -n1) != '3.1.0' ]; then
-  bundle exec rake db:create db:migrate
-  bundle exec rake db:seed
+  bundle exec rake db:create db:migrate --trace
+  bundle exec rake db:seed --trace
 fi
 
 cd $PLUGIN_ROOT

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -49,7 +49,7 @@ fi
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
-bundle exec rake db:drop db:create db:migrate DISABLE_DATABASE_ENVIRONMENT_CHECK=true
+bundle exec rake db:drop db:create db:migrate DISABLE_DATABASE_ENVIRONMENT_CHECK=true --trace
 
 ### END test_develop ###
 
@@ -71,12 +71,12 @@ while ! bundle update; do
 done
 
 # Now let's add the plugin migrations
-bundle exec rake db:migrate RAILS_ENV=development
+bundle exec rake db:migrate RAILS_ENV=development --trace
 
 tasks="jenkins:unit"
 [ ${database} = postgresql ] && tasks="$tasks jenkins:integration"
-bundle exec rake $tasks TESTOPTS="-v"
+bundle exec rake $tasks TESTOPTS="-v" --trace
 
 # Run the DB seeds to verify they work
-bundle exec rake db:drop db:create db:migrate
-bundle exec rake db:seed
+bundle exec rake db:drop db:create db:migrate --trace
+bundle exec rake db:seed --trace

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
@@ -38,8 +38,8 @@ done
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
-bundle exec rake db:drop db:create db:migrate
-bundle exec rake db:seed
+bundle exec rake db:drop db:create db:migrate --trace
+bundle exec rake db:seed --trace
 
 # Back to the pull request
 git checkout -
@@ -54,5 +54,5 @@ while ! bundle update -j5; do
   fi
 done
 
-bundle exec rake db:migrate
-bundle exec rake db:seed
+bundle exec rake db:migrate --trace
+bundle exec rake db:seed --trace


### PR DESCRIPTION
I'm getting some unexpected aborts on rake test command in remote
execution. I don't see reason hiding the trace when the rake calls in
our CI fail on exception. I believe this can help not just me but all
the future generations trying to figure out WTH it going on.