### PR TITLE
Drop & migrate on separate rake commands

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -49,7 +49,12 @@ fi
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
-bundle exec rake db:drop db:create db:migrate DISABLE_DATABASE_ENVIRONMENT_CHECK=true --trace
+bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true --trace
+# We drop and create in 2 separate commands (speed penalty, 2 Rails initializations)
+# as it's necessary to make sure at db:migrate models are loaded from a clean slate.
+# e.g: model Host isn't loaded with a 'type' attribute before the column is added
+# in the migration.
+bundle exec rake db:create db:migrate DISABLE_DATABASE_ENVIRONMENT_CHECK=true --trace
 
 ### END test_develop ###
 


### PR DESCRIPTION
The way this works currently, db:drop db:create db:migrate runs prior to
running the tests. This works, because when these 3 tasks are called by
rake, there is no environment, so the migrations cannot assume any
schema.

However, after the tests run, there's already an existing schema. When
we call db:drop, db:create db:migrate all 3 on the same rake command, by
the time we get to 'db:migrate' - the application has already loaded the
schema we had prior to db:drop, instead of an empty one.

This means, a call like "Host.unscoped.all" is translated to
"SELECT \"hosts\".* FROM \"hosts\" WHERE \"hosts\".\"type\" IN
('Host::Managed')""
when it should be:
"SELECT \"hosts\".* FROM \"hosts\"

This affects an early migration
20090916053824_change_host_build_default_to_false.rb, at that date,
there was no "type" column. This patch prevents the problem from
happening in other migrations as well.