### PR TITLE
Create foreman_datacenter.yaml

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_datacenter.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_datacenter.yaml
@@ -1,0 +1,6 @@
+- project:
+    name: foreman_datacenter
+    defaults: plugin
+    branch: develop
+    jobs:
+      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
Hi
I added some tests for a start
plugin's organization is still 'cloudevelops' - https://github.com/cloudevelops/foreman_datacenter
we already created deb package in foreman-packaging
is transfering organization to 'theforeman' necessary?