### PR TITLE
Specify branch for repoclosure

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
@@ -12,7 +12,7 @@
     builders:
       - trigger-builds:
         - project: packaging_repoclosure
-          predefined-parameters: "os=${os}\nrepo=foreman-${major_version}\npuppet_lookasides=${os}-puppet"
+          predefined-parameters: "os=${os}\nrepo=foreman-${major_version}\npuppet_lookasides=${os}-puppet\nbranch=${major_version}"
           block: true
       - trigger-builds:
         - project: systest_foreman


### PR DESCRIPTION
Repoclosure has 'develop' as a default branch which gets used because release_test does not pass it in predefined parameters.