### PR TITLE
Use tfm-ror51 in repoclosure

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_repoclosure.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_repoclosure.sh
@@ -65,7 +65,7 @@ if [ -n "${predefined_lookasides}" ]; then
   done
 fi
 
-options="yum_${os}.conf http://koji.katello.org/releases/yum/${repo}/${osname}/${osver}/x86_64/ -l ${os}-base -l ${os}-updates -l ${os}-extras -l ${os}-epel -l ${os}-scl -l ${os}-scl-sclo -l ${os}-scl-ruby -l ${os}-scl-v8 ${koji_lookaside} ${foreman_lookaside} ${copr_lookaside} ${puppet_lookaside} ${predefined_lookaside}"
+options="yum_${os}.conf http://koji.katello.org/releases/yum/${repo}/${osname}/${osver}/x86_64/ -l ${os}-base -l ${os}-updates -l ${os}-extras -l ${os}-epel -l ${os}-scl -l ${os}-scl-sclo -l ${os}-scl-ruby -l ${os}-tfm-ror51 -l ${os}-scl-v8 ${koji_lookaside} ${foreman_lookaside} ${copr_lookaside} ${puppet_lookaside} ${predefined_lookaside}"
 
 if [[ $1 == '--dry-run' ]]; then
   echo $options


### PR DESCRIPTION
tfm-ror51 is not used when testing [repoclosure](http://ci.theforeman.org/job/packaging_repoclosure/37707/console).