### PR TITLE
Allow pc1 repo for stretch

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
@@ -38,11 +38,7 @@ if [ -n "${expected_version}" ]; then
 fi
 
 if [ $pl_puppet = auto ]; then
-  if [ $os = stretch ]; then
-    pl_puppet=false  # no pc1 repo available
-  else
-    pl_puppet=pc1
-  fi
+  pl_puppet=pc1
 fi
 
 export VAGRANT_DEFAULT_PROVIDER=rackspace


### PR DESCRIPTION
The pc1 repo for stretch is now [available](https://tickets.puppetlabs.com/browse/PA-515?focusedCommentId=482629&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-482629), so we can use it in systest. I hope the missing [dependency errors](http://ci.theforeman.org/job/systest_foreman/14210/console) will disappear as stretch will have the puppet available. 