### PR TITLE
Add custom url for plugins in systest

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
@@ -16,7 +16,11 @@ if [ ${os#f} != $os ]; then
 elif [ ${os#el} != $os ]; then
   [ $repo != nightly ] && FOREMAN_REPO=releases/$repo
   args="FOREMAN_REPO=$FOREMAN_REPO"
-  [ $staging = true ] && args="FOREMAN_CUSTOM_URL=http://koji.katello.org/releases/yum/foreman-${repo}/RHEL/${os#el}/x86_64/ $args"
+  if [ $staging = true ]; then
+    foreman_url="FOREMAN_CUSTOM_URL=http://koji.katello.org/releases/yum/foreman-${repo}/RHEL/${os#el}/x86_64/"
+    foreman_plugins_url="FOREMAN_CUSTOM_PLUGINS_URL=http://koji.katello.org/releases/yum/foreman-plugins-${repo}/RHEL/${os#el}/x86_64/"
+    args="$foreman_url $foreman_plugins_url $args"
+  fi
 else
   if [ $staging = true ]; then
     args="FOREMAN_CUSTOM_URL=http://stagingdeb.theforeman.org/ FOREMAN_REPO=theforeman-${repo}"


### PR DESCRIPTION
Needs a change in [bats](https://github.com/theforeman/foreman-bats/pull/119) to work.