### PR TITLE
Fix release cron and pipeline job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
@@ -1,10 +1,6 @@
 pipeline {
     agent none
 
-    triggers {
-        cron('H 21 * * *')
-    }
-
     options {
         timestamps()
         timeout(time: 2, unit: 'HOURS')

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloRelease.groovy
@@ -1,10 +1,6 @@
 pipeline {
     agent none
 
-    triggers {
-        cron('H 23 * * *')
-    }
-
     options {
         timestamps()
         timeout(time: 2, unit: 'HOURS')

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-nightly-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-nightly-release.yaml
@@ -1,6 +1,8 @@
 - job:
     name: foreman-nightly-release
     project-type: workflow
+    triggers:
+      - timed: 'H 21 * * *'
     dsl:
       !include-raw:
         - pipelines/release/foremanRelease.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-plugins-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-plugins-release.yaml
@@ -1,6 +1,8 @@
 - job:
     name: foreman-plugins-release
     project-type: workflow
+    triggers:
+      - timed: 'H H * * *'
     dsl:
       !include-raw:
         - pipelines/release/foremanPluginsRelease.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/katello-nightly-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/katello-nightly-release.yaml
@@ -1,6 +1,8 @@
 - job:
     name: katello-nightly-release
     project-type: workflow
+    triggers:
+      - timed: 'H 23 * * *'
     dsl:
       !include-raw:
         - pipelines/release/katelloRelease.groovy


### PR DESCRIPTION
The cron trigger from the pipeline itself seemed to partially or never truly work. This reverts back to normal cron trigger on the job definition itself.

This also updates a bug in the plugins release pipeline where it never actually called `push_rpms` (oops). This also make a strategic change to do repoclosure + push per release stream. This prevents broken release streams from blocking others. i.e. in progress 1.17 doesn't block nightly.