### PR TITLE
Skip system checks for systest

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
@@ -66,6 +66,10 @@ if [ $pl_puppet != false ]; then
   echo PUPPET_REPO=${pl_puppet} fb-install-plpuppet.bats | vagrant ssh $os | tee fb-install-plpuppet.bats.out
 fi
 
+if [ $os = el7 ]; then
+  args="INSTALLER_OPTIONS=-s $args"
+fi
+
 echo ${args} fb-install-foreman.bats | vagrant ssh $os | tee fb-install-foreman.bats.out
 
 if [ $run_puppet_tests = true ]; then


### PR DESCRIPTION
el7 tests failing on DNS resolution for host, this should help. Needs a change in [bats](https://github.com/theforeman/foreman-bats/pull/120)