### PR TITLE
Update the kafo test matrix

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/kafo.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/kafo.sh
@@ -9,10 +9,7 @@ gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 # Update any gems from the global gemset
-# Don't update gems from the global gemset for Ruby 1.9*, io-console and json requires Ruby 2.0+
-if [[ ${ruby} == 2* ]]; then
-  gem update --no-ri --no-rdoc
-fi
+gem update --no-ri --no-rdoc
 gem install bundler --no-ri --no-rdoc
 
 # rename axis for Gemfile env var

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_kafo_master.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_kafo_master.yaml
@@ -19,8 +19,6 @@
           type: user-defined
           name: ruby
           values:
-          - 1.8.7
-          - 1.9.3
           - 2.0.0
           - 2.1
           - 2.2
@@ -30,14 +28,10 @@
           type: user-defined
           name: puppet
           values:
-          - 3.8.0
-          - 4.4.0
-          - 4.5.0
-          - 4.6.0
-          - 4.9.0
           - 4.10.0
+          - 5.0
     execution-strategy:
-      combination-filter: '!( (ruby ==~ /^2\.[2-9].*/ && puppet ==~ /^3\..*/) || (ruby ==~ /^1\..*/ && puppet ==~ /^4\..*/) )'
+      combination-filter: '!(ruby ==~ /^2\.[0-3]\..*/ && puppet ==~ /^5\..*/) )'
       touchstone:
         expr: 'ruby=="2.1" && puppet=="4.10.0"'
         result: 'stable'


### PR DESCRIPTION
While it may work on Ruby 1.x and old Puppet version, we no longer really care about it. This allows us to simplify the test matrix.