### PR TITLE
Split release_nightly_build foreman into rpm and deb

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_trigger_installer_develop.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_trigger_installer_develop.yaml
@@ -25,5 +25,7 @@
       - archive:
           artifacts: 'pkg/*'
           only-if-success: false
-      - release_nightly_build_foreman:
+      - release_nightly_build_foreman_rpm:
           project: packages/foreman/foreman-installer
+      - release_nightly_build_foreman_deb:
+          project: foreman-installer

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop.yaml
@@ -44,8 +44,10 @@
           only-if-success: false
       - junit:
           results: 'jenkins/reports/unit/*.xml'
-      - release_nightly_build_foreman:
+      - release_nightly_build_foreman_rpm:
           project: packages/foreman/foreman
+      - release_nightly_build_foreman_deb:
+          project: foreman
       - trigger-parameterized-builds:
         - project: test_katello
           condition: SUCCESS

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_proxy_develop.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_proxy_develop.yaml
@@ -44,5 +44,7 @@
       - archive:
           artifacts: 'pkg/*'
           only-if-success: true
-      - release_nightly_build_foreman:
+      - release_nightly_build_foreman_rpm:
           project: packages/foreman/foreman-proxy
+      - release_nightly_build_foreman_deb:
+          project: foreman-proxy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/release_nightly_build_foreman_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/release_nightly_build_foreman_deb.yaml
@@ -1,8 +1,8 @@
 - publisher:
-    name: release_nightly_build_foreman
+    name: release_nightly_build_foreman_deb
     publishers:
       - trigger-parameterized-builds:
-          - project: release_nightly_build_rpm, release_nightly_build_deb
+          - project: release_nightly_build_deb
             condition: SUCCESS
             predefined-parameters: |
               project={project}


### PR DESCRIPTION
@ekohl Thanks for the heads up. I split deb and rpm here to be explicit.