### PR TITLE
Purge old katello PR hook

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -74,7 +74,6 @@ class slave (
     'hammer_cli_foreman_discovery',
     'kafo',
     'kafo_parsers',
-    'katello',
     'katello_packaging',
     'puppetdb_foreman',
     'smart_proxy',
@@ -101,6 +100,13 @@ class slave (
       group   => 'jenkins',
       content => template('slave/hub_config.erb'),
     }
+  }
+
+  # Old jobs that were converted to JJB
+  slave::pr_test_config { [
+      'katello',
+    ]:
+      ensure => absent,
   }
 
   # Build dependencies


### PR DESCRIPTION
bf12835d0b08cad823eaf26f0a2e6ad0c8045589 removed the template without removing the actual config. This ensures the config is actually purged.