### PR TITLE
Only retrieve the relevant PR with GHPRB

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/foreman-packaging.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/foreman-packaging.yaml
@@ -31,4 +31,4 @@
           skip-tag: true
           branches:
             - '${ghprbActualCommit}'
-          refspec: '+refs/pull/*:refs/remotes/upstream/pr/*'
+          refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/upstream/pr/${ghprbPullId}/*'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/foreman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/foreman.yaml
@@ -15,4 +15,4 @@
           wipe-workspace: true
           branches:
             - '${ghprbActualCommit}'
-          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+          refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/kafo.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/kafo.yaml
@@ -14,4 +14,4 @@
           wipe-workspace: true
           branches:
             - '${ghprbActualCommit}'
-          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+          refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'


### PR DESCRIPTION
By setting this refspec we only retrieve the PR that we need to build
rather than every single PR. This saves a bandwidth, IO and thus time,
especially as the repository gets older.