### PR TITLE
Switch obal function to named parameters

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/obal.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/obal.groovy
@@ -1,13 +1,8 @@
-def obal(body) {
-
-    def config = [:]
-    body.resolveStrategy = Closure.DELEGATE_FIRST
-    body.delegate = config
-    body()
-
-    def tags = config.tags ? "--tags ${config.tags}" : ""
-    def extra_vars = config.extraVars ?: [:]
+def obal(args) {
     def extra_vars_file = 'extra_vars.yaml'
+
+    tags = args.tags ? "--tags ${args.tags}" : ""
+    extra_vars = args.extraVars ?: [:]
 
     writeYaml file: extra_vars_file, data: extra_vars
     archive extra_vars_file
@@ -17,6 +12,6 @@ def obal(body) {
     }
 
     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
-        sh "ANSIBLE_FORCE_COLOR=true PYTHONPATH=obal python -m obal ${tags} -e @${extra_vars_file} ${config.action} ${config.packages}"
+        sh "ANSIBLE_FORCE_COLOR=true PYTHONPATH=obal python -m obal ${tags} -e @${extra_vars_file} ${args.action} ${args.packages}"
     }
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/triggers/github_pr.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/triggers/github_pr.yaml
@@ -25,6 +25,7 @@
     triggers:
       - github-pull-request:
           <<: *ghprb_defaults
+          status-url: http://ci.theforeman.org/blue/organizations/jenkins/$JOB_NAME/detail/$JOB_NAME/$BUILD_ID/pipeline
           white-list-target-branches:
             - rpm/develop
 
@@ -34,4 +35,3 @@
       - github-pull-request:
           <<: *ghprb_defaults
           status-url: http://ci.theforeman.org/blue/organizations/jenkins/$JOB_NAME/detail/$JOB_NAME/$BUILD_ID/pipeline
-


### PR DESCRIPTION
My understanding is that with declarative pipelines, this style is more the norm and can avoid this error:

```
WorkflowScript: 39: Expected a step @ line 39, column 21.
                       action = "scratch"
```

Which happens if a closure is not wrapped in a `script {}` which is kinda ugly to double wrap.