### PR TITLE
Include git in the katello-pr-test

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/katello-pr-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/katello-pr-test.yaml
@@ -15,4 +15,5 @@
       !include-raw:
         - pipelines/test/testKatello.groovy
         - pipelines/lib/rvm.groovy
+        - pipelines/lib/git.groovy
         - pipelines/lib/foreman.groovy


### PR DESCRIPTION
7d96a8bd3d2896d78c1acc9ffb031bf21c42979c started to use the git lib so it must be included.