### PR TITLE
Use sha1 for pull request builder

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/git.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/git.groovy
@@ -1,7 +1,7 @@
 def ghprb_git_checkout() {
     checkout changelog: true, poll: false, scm: [
         $class: 'GitSCM',
-        branches: [[name: '${ghprbActualCommit}']],
+        branches: [[name: '${sha1}']],
         doGenerateSubmoduleConfigurations: false,
         extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'default', mergeTarget: '${ghprbTargetBranch}']]],
         submoduleCfg: [],


### PR DESCRIPTION
Attempting to fix (http://ci.theforeman.org/job/katello-pr-test/746/console) the test case we ran worked but was only a single data point.