### PR TITLE
Ignore db:drop failures in gemset_cleanup

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/gemset_cleanup.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/gemset_cleanup.sh
@@ -17,7 +17,7 @@ rvm use ruby-${ruby}@${gemset}
 set -x
 
 # Env var works around Rails issue #28001 if DB migrations fail
-bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true
+bundle exec rake db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=true || true
 
 echo "Delete gemset"
 set +x


### PR DESCRIPTION
This is not available in every job and can sometimes fail the build
while new builds already run db:drop at the start.