### PR TITLE
Wipe out old vagrant dirs

### DIFF
--- a/puppet/modules/slave/manifests/vagrant.pp
+++ b/puppet/modules/slave/manifests/vagrant.pp
@@ -33,12 +33,12 @@ class slave::vagrant(
     source   => "/root/vagrant-package-${vagrant_version}",
     provider => $vagrant_provider,
   } ->
-  exec { 'vagrant plugin uninstall vagrant-rackspace':
-    onlyif      => 'vagrant plugin list | grep vagrant-rackspace',
-    environment => ["HOME=${home}"],
-    user        => $user,
-    cwd         => $home,
-    provider    => 'shell',
+  # old installs need to be migrated and that's an interactive UI. Easier to wipe out the old config
+  exec { 'clean old vagrant':
+    command => "rm -rf ${home}/.vagrant.d",
+    onlyif  => "test -e ${home}/.vagrant.d/boxes/dummy/rackspace",
+    path    => ['/bin', '/usr/bin'],
+    user    => $user,
   } ->
   exec { 'vagrant plugin install /usr/local/src/vagrant-openstack-provider-0.12.0.pre.ed73861.gem':
     unless      => 'vagrant plugin list | grep vagrant-openstack-provider',
@@ -54,10 +54,6 @@ class slave::vagrant(
     group   => $user,
     mode    => '0600',
     content => template('slave/Vagrantfile.erb'),
-  }
-
-  file { [$ssh_key, "${ssh_key}.pub"]:
-    ensure => absent,
   }
 
   file { '/root/vagrant-openstack-provider-0.12.0.pre.ed73861.gem':


### PR DESCRIPTION
When upgrading from 1.4.2 to 2.0.2 vagrant wants to upgrade some
internal data. This shows an interactive prompt which needs a TTY. We
don't care about our boxes so it's easier to just remove the directory.
We only do this if we see the old rackspace dummy box to make it
idempotent.