### PR TITLE
Do no not run vagrant up with --debug

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/systest_foreman.sh
@@ -40,7 +40,7 @@ export VAGRANT_DEFAULT_PROVIDER=openstack
 
 trap "vagrant destroy $box_name" EXIT ERR
 
-vagrant up --debug $box_name || true
+vagrant up $box_name || true
 
 [ -e debug ] && rm -rf debug/
 mkdir debug


### PR DESCRIPTION
The debug info contains API auth tokens so this is a major security
issue.