### PR TITLE
Revert "Use sha1 for pull request builder"

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/git.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/git.groovy
@@ -1,7 +1,7 @@
 def ghprb_git_checkout() {
     checkout changelog: true, poll: false, scm: [
         $class: 'GitSCM',
-        branches: [[name: '${sha1}']],
+        branches: [[name: '${ghprbActualCommit}']],
         doGenerateSubmoduleConfigurations: false,
         extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'default', mergeTarget: '${ghprbTargetBranch}']]],
         submoduleCfg: [],


### PR DESCRIPTION
I don't think this change helped us. In fact, I'm starting to think we should definitely revert it asap.

This reverts commit 4fe4e86f06093331521e97bc1765ed2806f92dc6.