### PR TITLE
Update the refspec to include the base branch

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/git.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/git.groovy
@@ -6,7 +6,7 @@ def ghprb_git_checkout() {
         extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeStrategy: 'default', mergeTarget: '${ghprbTargetBranch}']]],
         submoduleCfg: [],
         userRemoteConfigs: [
-            [refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*', url: 'https://github.com/${ghprbGhRepository}']
+            [refspec: '+refs/heads/${ghprbTargetBranch}:refs/remotes/origin/${ghprbTargetBranch} +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*', url: 'https://github.com/${ghprbGhRepository}']
         ]
     ]
 }


### PR DESCRIPTION
This will fetch both the PR ref and the base branch ref (i.e. master).

I'm hoping this will produce the following (e.g.) fetch:

```sh
git fetch --tags --progress https://github.com/Katello/katello '+refs/heads/master:refs/remotes/origin/master' '+refs/pull/7197/*:refs/remotes/origin/pr/7197/*'
```

Relevant docs https://github.com/jenkinsci/ghprb-plugin#creating-a-job