### PR TITLE
Fix systest bats reporting

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/systest_foreman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/systest_foreman.yaml
@@ -2,11 +2,11 @@
     name: systest_foreman
     publishers:
     - archive:
-        artifacts: 'debug/*,*.bats.out,*.tap'
+        artifacts: 'debug/*'
         allow-empty: true
         only-if-success: false
     - tap:
-        results: '*.bats.out'
+        results: 'debug/*.tap'
         fail-if-no-results: true
         failed-tests-mark-build-as-failure: true
         enable-subtests: false


### PR DESCRIPTION
Forklift outputs test.tap files. This change ensures Jenkins can find
the correct results.