### PR TITLE
Increase rackspace timeouts

### DIFF
--- a/puppet/modules/slave/templates/Vagrantfile.erb
+++ b/puppet/modules/slave/templates/Vagrantfile.erb
@@ -10,5 +10,7 @@ Vagrant.configure('2') do |config|
     os.username = '<%= @username.unwrap -%>'
     os.password = '<%= @password.unwrap -%>'
     os.tenant_name = '<%= @tenant_name.unwrap -%>'
+    os.server_create_timeout = 500
+    os.server_active_timeout = 500
   end
 end


### PR DESCRIPTION
In various jobs I've seen that it can take longer than the default 200
seconds for a server to come up. Hopefully these values are a bit safer.