### PR TITLE
Use gitrelease on rpm scratch builds

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_test_pull_request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_test_pull_request.yaml
@@ -48,6 +48,7 @@
         - project: packaging_build_rpm
           block: true
           predefined-parameters: |
+            gitrelease=true
             scratch=true
             branch=${ghprbTargetBranch}
             pr_number=${ghprbPullId}


### PR DESCRIPTION
Should add `--test` to scratch builds so that tito does not complain about missing tags when testing PRs