### PR TITLE
Block release_packages on building rpms

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_packages.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_packages.yaml
@@ -27,6 +27,7 @@
       - trigger-builds:
         - project: packaging_build_rpm
           predefined-parameters: "branch=rpm/${major_version}\nproject=${project}\nscratch=false\ngitrelease=false"
+          block: true
       - conditional-step:
           condition-kind: not
           condition-operand:


### PR DESCRIPTION
Since we block on debs, maybe we should have the same for rpms.