### PR TITLE
Fix scoping on copr template

### DIFF
--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -1,6 +1,9 @@
 # All RPM packaging tools
 class slave::packaging::rpm (
   Optional[String] $koji_certificate = $slave::koji_certificate,
+  Optional[String] $copr_login = $slave::copr_login,
+  Optional[String] $copr_username = $slave::copr_username,
+  Optional[String] $copr_token = $slave::copr_token,
 ) {
   package { ['koji', 'rpm-build', 'git-annex', 'pyliblzma']:
     ensure => latest,


### PR DESCRIPTION
5f4579b29e5e76a34140e70dff2294cad71873d1 split copr config into a separate file but that took the copr variables out of scope.