### PR TITLE
Limit vagrant jobs to hosts with ipv6

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
@@ -26,7 +26,7 @@ pipeline {
             }
         }
         stage('Install Test') {
-            agent { label 'el' }
+            agent { label 'el && ipv6' }
 
             environment {
                 VAGRANT_DEFAULT_PROVIDER = 'openstack'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloRelease.groovy
@@ -31,7 +31,7 @@ pipeline {
             }
         }
         stage('Pulp Repoclosure') {
-            agent { label 'el' }
+            agent { label 'el && ipv6' }
 
             steps {
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-discovery-image-publish.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-discovery-image-publish.yaml
@@ -1,6 +1,6 @@
 - job:
     name: foreman-discovery-image-publish
-    node: 'admin && el && sshkey'
+    node: 'admin && el && sshkey && ipv6'
     logrotate:
       daysToKeep: 90
       numToKeep: 30

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/systest_foreman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/systest_foreman.yaml
@@ -1,6 +1,6 @@
 - job:
     name: systest_foreman
-    node: 'el'
+    node: 'el && ipv6'
     concurrent: true
     logrotate:
       daysToKeep: 8


### PR DESCRIPTION
Because we provision on Rackspace (which has IPv6) and the vagrant-openstack-plugin can't decide which IP it should use, we pin to nodes with IPv6.