### PR TITLE
Install npm for plugins in test job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -75,6 +75,11 @@ while ! bundle update; do
   fi
 done
 
+# If the plugin contains npm deps, we need to install its specific modules
+if [ -e "$PLUGIN_ROOT/package.json" ]; then
+  $APP_ROOT/node_modules/.bin/npm install
+fi
+
 # Now let's add the plugin migrations
 bundle exec rake db:migrate RAILS_ENV=development --trace
 


### PR DESCRIPTION
Currently the plugins with webpack assets, are not getting their
dependencies fulfilled and webpack always fails to compile in the
test_plugin_pull_request job. The reason is that `npm install` is ran
**before** putting the plugin in the gemfile.

This change runs `npm install` a second time after the Gemfile has been
updated to ensure we have the npm dependencies ready for webpack.

https://github.com/theforeman/foreman_remote_execution/pull/130 for example benefited from this change (I changed it manually on Jenkins)