### PR TITLE
test_brakeman - convert to JJB

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_brakeman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_brakeman.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+ruby=2.4.3
+
+# RVM Ruby environment
+. /etc/profile.d/rvm.sh
+# Use a gemset unique to each executor to enable parallel builds
+gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
+rvm use ruby-${ruby}@${gemset} --create
+rvm gemset empty --force
+gem install brakeman --no-ri --no-rdoc
+
+cp config/settings.yaml.example config/settings.yaml
+brakeman -o brakeman_output.json --no-progress --separate-models
+exit 0

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_brakeman.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_brakeman.yaml
@@ -1,0 +1,18 @@
+- job:
+    name: test_brakeman_temp
+    scm:
+      - git:
+          url: https://github.com/theforeman/foreman
+          per-build-tag: true
+          wipe-workspace: true
+          branches:
+            - develop
+    triggers:
+      - github
+      - scm_fifteen_minutes
+    builders:
+      - shell: !include-raw: scripts/test/test_brakeman.sh
+    publishers:
+      - gemset_cleanup
+      - brakeman:
+          output: brakeman_output.json


### PR DESCRIPTION
we need to get the JJB-brakeman plugin [1] added to this repo. i'm not sure how to do that. otherwise `update_jobs.sh` will complain about not understanding the `brakeman` entry point in publishers.

[1] https://github.com/garethr/jenkins-job-builder-brakeman