### PR TITLE
Drop db:seed run from develop tests

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -47,7 +47,3 @@ bundle exec rake db:drop db:create db:migrate --trace
 tasks="pkg:generate_source jenkins:unit"
 [ ${database} = postgresql ] && tasks="$tasks jenkins:integration"
 bundle exec rake $tasks TESTOPTS="-v" --trace
-
-# Run the DB seeds to verify they work
-bundle exec rake db:drop db:create db:migrate --trace
-bundle exec rake db:seed --trace


### PR DESCRIPTION
we already have tests for the seeds in core, no need to rerun the seeds. This was added mostly to make sure plugin seeds run properly.