### PR TITLE
Install npm assets just once

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -35,12 +35,6 @@ while ! bundle install --without=development -j5; do
   fi
 done
 
-# we need to install node modules for integration tests
-if [ -e "$APP_ROOT/package.json" ]; then
-  npm install npm@'<6.0.0' # first upgrade to newer npm
-  $APP_ROOT/node_modules/.bin/npm install
-fi
-
 # Database environment
 (
   sed "s/^test:/development:/; s/database:.*/database: ${gemset}-dev/" $HOME/${database}.db.yaml
@@ -76,7 +70,9 @@ while ! bundle update; do
 done
 
 # If the plugin contains npm deps, we need to install its specific modules
-if [ -e "$PLUGIN_ROOT/package.json" ]; then
+# we need to install node modules for integration tests
+if [ -e "$APP_ROOT/package.json" ]; then
+  npm install npm@'<6.0.0' # first upgrade to newer npm
   $APP_ROOT/node_modules/.bin/npm install
 fi
 


### PR DESCRIPTION
Trying to run `npm install` after `npm install npm` works.
However, the 2nd time it runs, to install the plugin npm dependencies,
it fails.

The reason is that 'node_modules/.bin/npm install' can only
run once. After it runs, since 'npm' is not a dependency of Foreman in
package.json, it will just erase it.

To fix this, I am just installing npm once and then calling
`node_modules/.bin/npm install` *after* the Gemfile contains the
plugin. This ensures we install both Foreman npm deps and plugin's deps.

Example of broken tests because of this:
 - http://ci.theforeman.org/job/test_plugin_matrix/5164/database=postgresql,ruby=2.4,slave=fast/consoleFull
 - http://ci.theforeman.org/job/test_plugin_matrix/5147/database=postgresql,ruby=2.3,slave=fast/console

Example of :+1:  tests after the fix is applied to the job:
 - http://ci.theforeman.org/job/test_plugin_foreman_remote_execution_master/522
 - http://ci.theforeman.org/job/test_plugin_foreman_ansible_master/222/