### PR TITLE
do not require downstream stability

### DIFF
--- a/puppet/modules/slave/templates/test_pull_requests_foreman_bootdisk.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_bootdisk.json.erb
@@ -21,6 +21,7 @@
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_bootdisk_master",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_bootdisk": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_digitalocean.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_digitalocean.json.erb
@@ -21,6 +21,7 @@
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_digitalocean_master",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman-digitalocean": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_discovery.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_discovery.json.erb
@@ -21,6 +21,7 @@
                 "develop": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_discovery_develop",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_discovery": {
@@ -32,6 +33,7 @@
                 "2.0-stable": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_discovery_2.0_stable",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_discovery": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_expire_hosts.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_expire_hosts.json.erb
@@ -21,6 +21,7 @@
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_expire_hosts_master",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_expire_hosts": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_host_extra_validator.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_host_extra_validator.json.erb
@@ -21,6 +21,7 @@
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_host_extra_validator_master",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_host_extra_validator": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_monitoring.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_monitoring.json.erb
@@ -20,6 +20,7 @@
             "branches": {
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
+                    "require_downstream_stability": false,
                     "downstream_job_name": "test_plugin_foreman_monitoring_master",
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_omaha.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_omaha.json.erb
@@ -21,6 +21,7 @@
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_omaha_master",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_omaha": {

--- a/puppet/modules/slave/templates/test_pull_requests_foreman_userdata.json.erb
+++ b/puppet/modules/slave/templates/test_pull_requests_foreman_userdata.json.erb
@@ -21,6 +21,7 @@
                 "*": {
                     "jenkins_job_name": "test_plugin_pull_request",
                     "downstream_job_name": "test_plugin_foreman_userdata_master",
+                    "require_downstream_stability": false,
                     "build_token": "<%= @jenkins_build_token -%>",
                     "addtl_jenkins_params": {
                         "foreman_userdata": {


### PR DESCRIPTION
This should disable the `Waiting for stable build of` message, see https://github.com/openshift/test-pull-requests/blob/699cc3085e3a1cd090d9c185781bf676ab183191/test_pull_requests#L2253 for reference.

cc: @lzap, @ehelms