### PR TITLE
Bundle exec npm install within foreman

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -102,7 +102,7 @@ pipeline {
                     steps {
                         dir('foreman') {
                             sh "npm install npm"
-                            sh "node_modules/.bin/npm install"
+                            sh "bundle exec node_modules/.bin/npm install"
                             withRVM(['bundle exec rake plugin:assets:precompile[katello] RAILS_ENV=production --trace'], ruby)
                         }
                     }


### PR DESCRIPTION
should work around the issue of `/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler (LoadError)`  during an npm install