### PR TITLE
test_katello_rubocop - remove _temp suffix

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_katello_rubocop.yml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_katello_rubocop.yml
@@ -1,5 +1,5 @@
 - job:
-    name: test_katello_rubocop_temp
+    name: test_katello_rubocop
     description: |
       Run Katello Rubocop tests
     concurrent: true


### PR DESCRIPTION
[test_katello_rubocop_temp](http://ci.theforeman.org/job/test_katello_rubocop_temp) will need to be deleted after this is merged.