### PR TITLE
fix labels for systest family jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-hammer-nightly-systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-hammer-nightly-systest.yaml
@@ -1,6 +1,5 @@
 - job:
     name: foreman-hammer-nightly-systest
-    node: 'el && ipv6'
     project-type: matrix
     logrotate:
       daysToKeep: 8
@@ -15,6 +14,12 @@
           name: os
           values:
             - centos7
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     builders:
       - systest:
           repo: nightly

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-mysql-nightly-systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-mysql-nightly-systest.yaml
@@ -1,6 +1,5 @@
 - job:
     name: foreman-mysql-nightly-systest
-    node: 'el && ipv6'
     project-type: matrix
     logrotate:
       daysToKeep: 8
@@ -16,6 +15,12 @@
             - centos7
             - debian9
             - ubuntu1604
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     builders:
       - systest:
           repo: nightly

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-puppet-nightly-systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-puppet-nightly-systest.yaml
@@ -1,7 +1,6 @@
 - job:
     name: foreman-puppet-nightly-systest
     disabled: true
-    node: 'el && ipv6'
     project-type: matrix
     logrotate:
       daysToKeep: 8
@@ -17,6 +16,12 @@
             - centos7
             - debian9
             - ubuntu1604
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     builders:
       - systest:
           repo: nightly

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-puppet-pc1-systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-puppet-pc1-systest.yaml
@@ -1,6 +1,5 @@
 - job:
     name: foreman-puppet-pc1-systest
-    node: 'el && ipv6'
     project-type: matrix
     logrotate:
       daysToKeep: 8
@@ -14,6 +13,12 @@
           name: os
           values:
             - centos7
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     builders:
       - systest:
           repo: nightly

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-umask-077-systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-umask-077-systest.yaml
@@ -1,6 +1,5 @@
 - job:
     name: foreman-umask-077-systest
-    node: 'el && ipv6'
     project-type: matrix
     logrotate:
       daysToKeep: 8
@@ -16,6 +15,12 @@
             - centos7
             - debian9
             - ubuntu1604
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     builders:
       - systest:
           repo: nightly

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_test_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_test_deb.yaml
@@ -1,6 +1,5 @@
 - job:
     name: release_nightly_test_deb
-    node: 'el && ipv6'
     project-type: matrix
     block-downstream: true
     block-upstream: true
@@ -18,6 +17,12 @@
           values:
           - debian9
           - ubuntu1604
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     builders:
       - systest:
           repo: nightly

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
@@ -1,7 +1,5 @@
-# Testing already-built RPMs from Koji and Debian packages in stagingdeb.
 - job:
     name: release_test
-    node: 'el && ipv6'
     project-type: matrix
     logrotate:
       daysToKeep: 8
@@ -31,6 +29,12 @@
           - debian8
           - debian9
           - ubuntu1604
+      - axis:
+          type: slave
+          name: label
+          values:
+            - el
+            - ipv6
     execution-strategy:
       combination-filter: 'os != "debian8" || major_version == "1.16"'
     wrappers:


### PR DESCRIPTION
systest jobs were complaining about an unreachable host and bombing out.

i think i've figured out that `node: 'el && ipv6'` only works for non-matrix jobs.