### PR TITLE
Add events redirect for calendar and ICS file

### DIFF
--- a/puppet/modules/web/templates/web.conf.erb
+++ b/puppet/modules/web/templates/web.conf.erb
@@ -4,6 +4,9 @@ RewriteRule   ^/issues(.*)  https://projects.theforeman.org/issues$1  [R,L]
 RewriteRule   ^/versions(.*)  https://projects.theforeman.org/versions$1  [R,L]
 RewriteRule   ^/wiki(.*)  https://projects.theforeman.org/wiki$1  [R,L]
 
+RewriteRule   ^/events/all.ics https://community.theforeman.org/c/events/l/calendar.ics [R,L]
+RewriteRule   ^/events/? https://community.theforeman.org/c/events/l/calendar [R,L]
+
 <% if @https -%>
 RewriteCond   %{HTTPS} !=on
 RewriteRule   ^/?(.*) https://%{SERVER_NAME}/$1 [R=301,L]


### PR DESCRIPTION
As per https://community.theforeman.org/t/moving-event-data-to-discourse/8971/3 this redirects the calendar and ICS file to the equivalents on Discourse.