### PR TITLE
Escape $ in tarballsRelease.groovy

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
@@ -57,7 +57,7 @@ pipeline {
 void verify_tag(project, version) {
     dir(project) {
         git url: "https://github.com/theforeman/${project}", branch: 'develop'
-        sh "test \"$(git tag -l ${version} | wc -l)\" -eq 1"
+        sh "git tag -l ${version} | grep ${version}"
     }
 }
 


### PR DESCRIPTION
Should fix [tarballs-release](http://ci.theforeman.org/blue/organizations/jenkins/tarballs-release/detail/tarballs-release/1/pipeline)