### PR TITLE
remove build_rpm_rubygem-hammer_cli_katello_nightly job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/build/build_rpm_rubygem_katello_nightly.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/build/build_rpm_rubygem_katello_nightly.yaml
@@ -30,10 +30,3 @@
     jenkins_job: 'test_katello_core'
     jobs:
       - 'build_rpm_{name}_{version}'
-
-- project:
-    name: 'rubygem-hammer_cli_katello'
-    version: 'nightly'
-    jenkins_job: 'release_build_hammer_cli_katello'
-    jobs:
-      - 'build_rpm_{name}_{version}'


### PR DESCRIPTION
double check that [build_rpm_rubygem-hammer_cli_katello_nightly](http://ci.theforeman.org/job/build_rpm_rubygem-hammer_cli_katello_nightly) is gone after this is merged.