### PR TITLE
Fix pipeline syntax

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
@@ -8,9 +8,11 @@ pipeline {
         ansiColor('xterm')
     }
 
-    def version = env.getProperty('version')
-    def major_version = env.getProperty('major_version')
-    def ruby_ver = '2.4.0'
+    environment {
+        version = env.getProperty('version')
+        major_version = env.getProperty('major_version')
+        ruby_ver = '2.4.0'
+    }
 
     stages {
         stage('Parallel') {


### PR DESCRIPTION
Pipeline does not expect declared variables, so I replaced them with [environment directive](https://jenkins.io/doc/book/pipeline/syntax/#environment)