### PR TITLE
Fix upload folders, create separate gemsets

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -9,9 +9,13 @@ def gemset(name) {
     base_name
 }
 
-def configureRVM(ruby = '2.0') {
-    withRVM(['rvm gemset empty --force'], ruby)
-    withRVM(['gem install bundler'], ruby)
+def configureRVM(ruby = '2.0', name = '') {
+    emptyGemset(name, ruby)
+    withRVM(['gem install bundler'], ruby, name)
+}
+
+def emptyGemset(name = '', ruby = '2.0') {
+    withRVM(["rvm gemset empty ${gemset(name)} --force"], ruby)
 }
 
 def cleanupRVM(name = '', ruby = '2.0') {


### PR DESCRIPTION
I changed the base_dir so that the tarballs are uploaded to proper directory and not all to 'foreman'.

Each project name is now added to a gemset name, so that parallel branches do not clash with each other.  