### PR TITLE
Make installer options an array

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
@@ -46,7 +46,7 @@
               variables:
                 bats_environment:
                 - FOREMAN_EXPECTED_VERSION: ${{expected_version}}
-                ${{args:+foreman_installer_options:${{args}}}}
+                ${{args:+foreman_installer_options:["${{args}}"]}}
                 ${{umask:+umask_mode: ${{umask}}}}
                 ${{repo:+foreman_repositories_version: ${{repo}}}}
                 ${{repo_environment:+foreman_repositories_environment: ${{repo_environment}}}}


### PR DESCRIPTION
Forklift now requires foreman_installer_options to be an array.