### PR TITLE
Handle the case where there are no unmanaged jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/unmanaged_jobs.rb
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/unmanaged_jobs.rb
@@ -39,14 +39,18 @@ def main
   fail "must supply ini file" if ARGV.empty?
   fail "too many arguments" if ARGV.size > 1
 
-  url = get_jenkins_url_from_ini(ARGV.pop)
+  inifile = ARGV.pop
+
+  url = get_jenkins_url_from_ini(inifile)
   fail "url is blank" unless url
 
   payload = Net::HTTP.get(url, '/api/json?tree=jobs[name,description]')
 
   unmanaged_jobs = find_unmanaged_jobs_from_payload(payload)
 
-  puts format_jobs_for_output(unmanaged_jobs)
+  unless unmanaged_jobs.empty?
+    `jenkins-jobs --conf #{inifile} delete --jobs-only #{format_jobs_for_output(unmanaged_jobs)}`
+  end
 end
 
 if __FILE__ == $0

--- a/puppet/modules/jenkins_job_builder/manifests/config.pp
+++ b/puppet/modules/jenkins_job_builder/manifests/config.pp
@@ -41,7 +41,7 @@ define jenkins_job_builder::config (
   }
 
   exec { "remove_unmanaged_jobs-${config_name}":
-    command => "jenkins-jobs --conf ${inifile} delete --jobs-only $(ruby ${directory}/${config_name}/unmanaged_jobs.rb ${inifile})",
+    command => "ruby ${directory}/${config_name}/unmanaged_jobs.rb ${inifile}",
     timeout => $jenkins_jobs_update_timeout,
     path    => '/bin:/usr/bin:/usr/local/bin',
     require => File[$inifile],


### PR DESCRIPTION
This still doesn't make it idempotent, but it shouldn't bork when
unmanaged_jobs.rb returns an empty string because there are no unmanaged
jobs.

Note this is untested and there's probably a much cleaner way to do this.