### PR TITLE
Clean the workspace when releasing tarballs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
@@ -70,7 +70,10 @@ void build_tarball(project, version, ruby_ver) {
     dir(project) {
         checkout scm: [$class: 'GitSCM',
             userRemoteConfigs: [[url: "https://github.com/theforeman/${project}.git"]],
-            branches: [[name: "refs/tags/${version}"]]], changelog: false, poll: false
+            branches: [[name: "refs/tags/${version}"]]],
+            changelog: false,
+            poll: false,
+            clearWorkspace: true
 
         configureRVM(ruby_ver, project)
 


### PR DESCRIPTION
This ensures we have no files like Gemfile.lock left behind from any previous run.