### PR TITLE
Clean up legacy RPM package testing

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_build_rpm.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_build_rpm.sh
@@ -24,7 +24,7 @@ mkdir rel-eng/build
 args="-o $(pwd)/rel-eng/build/"
 [ -n "${tag}" ] && args="$args --tag=$tag"
 [ x"${scratch}" != xfalse ] && args="$args --scratch"
-[ x"${gitrelease}" != xfalse -a x${releaser} != xkoji-foreman-nightly ] && args="$args --test"
+[ x"${gitrelease}" != xfalse -a x${releaser} != xkoji-foreman-nightly -a x${releaser} != xkoji-foreman-jenkins ] && args="$args --test"
 [ -n "${nightly_jenkins_job}" ] && args="$args --arg jenkins_job=${nightly_jenkins_job}"
 [ -n "${nightly_jenkins_job_id}" ] && args="$args --arg jenkins_job_id=${nightly_jenkins_job_id}"
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_rpm.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_rpm.sh
@@ -8,11 +8,7 @@ git --version
 merge_base=$(git merge-base HEAD upstream/${ghprbTargetBranch})
 
 # identify changed projects, 15 at most!
-if [ -d packages ]; then
-  to_build=$(git diff --name-only $merge_base HEAD | grep spec | grep packages | tail -n15)
-else
-  to_build=$(git diff --name-only $merge_base HEAD | grep spec | tail -n15)
-fi
+to_build=$(git diff --name-only $merge_base HEAD | grep spec | tail -n15)
 
 echo $to_build
 
@@ -25,80 +21,23 @@ for p in $to_build; do
   p=${p/.spec}
   mkdir -p test_builds/rpm/${p}
 
-  if [ $ghprbTargetBranch = "rpm/develop" ]; then
-    case "$p" in
-      foreman)
-        echo "nightly_jenkins_job=test_develop" >> test_builds/rpm/${p}.properties
-        r=koji-foreman-nightly
-        ;;
-      foreman-proxy)
-        echo "nightly_jenkins_job=test_proxy_develop" >> test_builds/rpm/${p}.properties
-        r=koji-foreman-nightly
-        ;;
-      foreman-selinux)
-        echo "nightly_jenkins_job=packaging_trigger_selinux_develop" >> test_builds/rpm/${p}.properties
-        r=koji-foreman-nightly
-        ;;
-      foreman-installer)
-        echo "nightly_jenkins_job=packaging_trigger_installer_develop" >> test_builds/rpm/${p}.properties
-        r=koji-foreman-nightly
-        ;;
-      rubygem-katello)
-        echo "nightly_jenkins_job=test_katello_core" >> test_builds/rpm/${p}.properties
-        echo "gitrelease=false" >> test_builds/rpm/${p}.properties
-        r=koji-katello-jenkins
-        ;;
-      katello-installer)
-        echo "nightly_jenkins_job=release_build_katello_installer" >> test_builds/rpm/${p}.properties
-        r=koji-katello-jenkins
-        echo "gitrelease=false" >> test_builds/rpm/${p}.properties
-        ;;
-      *)
-        if [[ -d packages ]] ; then
-          echo "gitrelease=true" >> test_builds/rpm/${p}.properties
-          if [[ $subdir == "katello" ]] ; then
-            r=koji-katello
-          elif [[ $subdir == "plugins" ]] ; then
-            r=koji-foreman-plugins
-          else
-            r=koji-foreman
-          fi
-        else
-          r=""
-        fi
-        ;;
-    esac
-  fi
-
-  if [[ -d packages ]] ; then
+  if [[ $project == *"katello"* && -z "$r" ]]; then
+    echo "project=${project}" >> test_builds/rpm/${p}.properties
+    mv test_builds/rpm/${p}.properties test_builds/rpm/${p}-katello.properties
+    echo "releaser=koji-katello" >> test_builds/rpm/${p}-katello.properties
+    echo "releaser=koji-katello-client" >> test_builds/rpm/${p}-katello.properties
+    echo "gitrelease=true" >> test_builds/rpm/${p}-katello.properties
+  elif [ -z "$r" ]; then
+    # build once for main releaser, once for plugins (one or both may be no-ops)
+    echo "project=${project}" >> test_builds/rpm/${p}.properties
+    cp test_builds/rpm/${p}.properties test_builds/rpm/${p}-plugins.properties
+    cp test_builds/rpm/${p}.properties test_builds/rpm/${p}-katello.properties
+    echo "releaser=koji-foreman" >> test_builds/rpm/${p}.properties
+    echo "releaser=koji-foreman-plugins" >> test_builds/rpm/${p}-plugins.properties
+    echo "gitrelease=true" >> test_builds/rpm/${p}.properties
+    echo "gitrelease=true" >> test_builds/rpm/${p}-plugins.properties
+  else
     echo "project=${project}" >> test_builds/rpm/${p}.properties
     echo "releaser=${r}" >> test_builds/rpm/${p}.properties
-
-    if [[ $subdir == "katello" ]] ; then
-      mv test_builds/rpm/${p}.properties test_builds/rpm/${p}-katello.properties
-      echo "releaser=koji-katello-client" >> test_builds/rpm/${p}-katello.properties
-    elif [[ $subdir == "plugins" ]] ; then
-      mv test_builds/rpm/${p}.properties test_builds/rpm/${p}-plugins.properties
-    fi
-  else
-    if [[ $project == *"katello"* && -z "$r" ]]; then
-      echo "project=${project}" >> test_builds/rpm/${p}.properties
-      mv test_builds/rpm/${p}.properties test_builds/rpm/${p}-katello.properties
-      echo "releaser=koji-katello" >> test_builds/rpm/${p}-katello.properties
-      echo "releaser=koji-katello-client" >> test_builds/rpm/${p}-katello.properties
-      echo "gitrelease=true" >> test_builds/rpm/${p}-katello.properties
-    elif [ -z "$r" ]; then
-      # build once for main releaser, once for plugins (one or both may be no-ops)
-      echo "project=${project}" >> test_builds/rpm/${p}.properties
-      cp test_builds/rpm/${p}.properties test_builds/rpm/${p}-plugins.properties
-      cp test_builds/rpm/${p}.properties test_builds/rpm/${p}-katello.properties
-      echo "releaser=koji-foreman" >> test_builds/rpm/${p}.properties
-      echo "releaser=koji-foreman-plugins" >> test_builds/rpm/${p}-plugins.properties
-      echo "gitrelease=true" >> test_builds/rpm/${p}.properties
-      echo "gitrelease=true" >> test_builds/rpm/${p}-plugins.properties
-    else
-      echo "project=${project}" >> test_builds/rpm/${p}.properties
-      echo "releaser=${r}" >> test_builds/rpm/${p}.properties
-    fi
   fi
 done


### PR DESCRIPTION
This script is only used on rpm/1.16 and rpm/1.17 so we can drop the rpm/develop specific code. They also don't have a packages directory so that can be dropped too.