### PR TITLE
Remove post action for tarballs-release

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tarballsRelease.groovy
@@ -45,15 +45,6 @@ pipeline {
             }
         }
     }
-
-    post {
-        success {
-            build job: 'release_packages', parameters: [
-                [$class: 'StringParameterValue', name: 'version', value: version],
-                [$class: 'StringParameterValue', name: 'major_version', value: major_version]
-            ]
-        }
-    }
 }
 
 void verify_tag(project, version) {


### PR DESCRIPTION
The `release_packages` task always fails because manual steps are needed to proceed - signatures must be uploaded and foreman-packaging updated.