### PR TITLE
Bind the katello test step to ipv6

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloRelease.groovy
@@ -30,7 +30,7 @@ pipeline {
             }
         }
         stage('Pulp Repoclosure') {
-            agent { label 'el && ipv6' }
+            agent { label 'el' }
 
             steps {
 
@@ -57,7 +57,7 @@ pipeline {
             }
         }
         stage('Install Test') {
-            agent { label 'el' }
+            agent { label 'el && ipv6' }
 
             environment {
                 VAGRANT_DEFAULT_PROVIDER = 'openstack'


### PR DESCRIPTION
This ensures it runs correctly on a node with IPv6 which we need for
forklift.