### PR TITLE
Update release_packages job for 1.18+ style

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_packages.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_packages.yaml
@@ -23,7 +23,7 @@
     builders:
       - trigger-builds:
         - project: packaging_build_rpm
-          predefined-parameters: "branch=rpm/${major_version}\nproject=${project}\nscratch=false\ngitrelease=false"
+          predefined-parameters: "branch=rpm/${major_version}\nproject=packages/foreman/${project}\nscratch=false\ngitrelease=false"
           block: true
       - conditional-step:
           condition-kind: not


### PR DESCRIPTION
This breaks the 1.17 release but it's hard to support both. With 1.19 being branched we are more likely to use this style than the old one.