### PR TITLE
Add eslint task to katello pipeline

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -74,6 +74,7 @@ pipeline {
                     steps {
                         sh "npm install npm"
                         sh "node_modules/.bin/npm install"
+                        sh 'npm run lint'
                         sh 'npm test'
                     }
                 }


### PR DESCRIPTION
This adds eslint testing to katello PRs, currently this does
not exist.