### PR TITLE
Test releases on PostgreSQL

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_test.yaml
@@ -17,7 +17,7 @@
           repo_environment: staging
           pl_puppet: ''
           run_hammer_tests: false
-          db_type: mysql
+          db_type: ''
           umask: ''
           expected_version: '${version}'
     axes:


### PR DESCRIPTION
We've always tested releases with PostgreSQL but in c57d43f0af47cecc867bf6d65b1ce8ae8c82cb6c this was changed to MySQL.  Probably unintentional.