### PR TITLE
Correctly pass in the FOREMAN_EXPECTED_VERSION

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
@@ -45,7 +45,7 @@
               group: 'bats'
               variables:
                 bats_environment:
-                  - FOREMAN_EXPECTED_VERSION: ${{expected_version}}
+                  FOREMAN_EXPECTED_VERSION: ${{expected_version}}
                 foreman_installer_options:
                   - '${{args}}'
                 ${{umask:+umask_mode: ${{umask}}}}


### PR DESCRIPTION
Otherwise you'd get

```
 [WARNING]: could not parse environment value, skipping: [u'{{ bats_environment
}}']
```