### PR TITLE
Allow version and release check to work more broadly

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
@@ -67,14 +67,15 @@ pipeline {
                         def index = i
                         packages[packages_to_build[index]] = {
                             package_name = packages_to_build[index]
+                            spec_path = sh(returnStdout: true, script: "find -name \"${package_name}\\.spec\"").trim()
 
-                            new_version = query_rpmspec("packages/**/${package_name}/*.spec", '%{VERSION}')
-                            new_release = query_rpmspec("packages/**/${package_name}/*.spec", '%{RELEASE}')
+                            new_version = query_rpmspec(spec_path, '%{VERSION}')
+                            new_release = query_rpmspec(spec_path, '%{RELEASE}')
 
                             sh "git checkout origin/${env.ghprbTargetBranch}"
 
-                            old_version = query_rpmspec("packages/**/${package_name}/*.spec", '%{VERSION}')
-                            old_release = query_rpmspec("packages/**/${package_name}/*.spec", '%{RELEASE}')
+                            old_version = query_rpmspec(spec_path, '%{VERSION}')
+                            old_release = query_rpmspec(spec_path, '%{RELEASE}')
 
                             sh "git checkout -"
 


### PR DESCRIPTION
Find the spec file explicitly rather than relying on wildcard paths
that don't work for all packaging release workflows.