### PR TITLE
Fix folderChanged logic

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/folderChanged.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/folderChanged.groovy
@@ -5,7 +5,8 @@ def folderChanged(folders) {
     files_changed = readFile('files_changed').split('\n')
 
     for (int i = 0; i < folders.size(); i++) {
-        changed = changed || !files_changed.findAll { it =~ folders[i] }.empty
+        find_all = files_changed.findAll { it =~ folders[i] }
+        changed = changed || find_all.size() > 0
     }
 
     return changed


### PR DESCRIPTION
This was breaking after an update to ci.centos.org infrastructure which makes me think the Jenkins upgrade they did changed slightly how the groovy worked with the empty check. This makes it more robust against potential usage of empty on different data types.