### PR TITLE
Correct katello-installer nightly builds

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloInstallerNightlyRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katelloInstallerNightlyRelease.groovy
@@ -37,7 +37,7 @@ pipeline {
         stage('Trigger RPM Build') {
             steps {
                 build job: 'packaging_build_rpm', propagate: true, parameters: [
-                    string(name: 'project', value: 'packages/katello/katello-installer'),
+                    string(name: 'project', value: 'packages/katello/katello-installer-base'),
                     booleanParam(name: 'gitrelease', value: false),
                     booleanParam(name: 'scratch', value: false),
                     string(name: 'releaser', value: 'koji-katello-jenkins'),


### PR DESCRIPTION
https://github.com/theforeman/foreman-packaging/commit/b98dbee1c4b5fc5f575db0dd6c401a0bbb00fdc7 renamed the directory to match the package name. This reflects that change.