### PR TITLE
Do not add deb prefix automatically

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -6,7 +6,7 @@
           url: https://github.com/theforeman/foreman-packaging/
     scm:
       - foreman-deb-packaging:
-          branch: 'deb/${repo}'
+          branch: '${repo}'
     axes:
       - axis:
           type: user-defined


### PR DESCRIPTION
PRs opened against debians require prefix,
so we do not need to add it second time.