### PR TITLE
only list the koji task id in the description

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/koji.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/koji.groovy
@@ -5,7 +5,7 @@ def status_koji_links(repo) {
         taskinfo_yaml = readYaml text: taskinfo
         build_status = (taskinfo_yaml["State"] == 'failed') ? 'FAILURE' : 'SUCCESS'
         build_package = taskinfo_yaml["Request Parameters"]["Source"].split('/')[-1]
-        githubNotify credentialsId: 'github-token', account: 'theforeman', repo: repo, sha: "${ghprbActualCommit}", context: "koji/${build_package}", description: "koji task #${task} for ${build_package}" , status: build_status, targetUrl: "http://koji.katello.org/koji/taskinfo?taskID=${task}"
+        githubNotify credentialsId: 'github-token', account: 'theforeman', repo: repo, sha: "${ghprbActualCommit}", context: "koji/${build_package}", description: "koji task #${task}" , status: build_status, targetUrl: "http://koji.katello.org/koji/taskinfo?taskID=${task}"
     }
 }
 


### PR DESCRIPTION
the package name is already in the "context" and this makes the description better readable

requested by @ekohl in #762