### PR TITLE
Removes workaround for eslint in katello

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -92,13 +92,11 @@ pipeline {
                         }
 
                         sh "cp -rf \$(cat foreman/bastion-version) engines/bastion_katello/bastion-${bastion_version}"
-                        sh "rm .eslintrc"
                         dir('engines/bastion_katello') {
                             sh "npm install npm"
                             sh "node_modules/.bin/npm install bastion-${bastion_version}"
                             sh "grunt ci"
                         }
-                        sh "git checkout .eslintrc"
                     }
                 }
                 stage('assets-precompile') {


### PR DESCRIPTION
We added this workaround due to '.eslintrc' being
"up the tree" for angular tests run in  engines/
bastion_katello. The root .eslintrc is for
React code. A Katello PR will move the .eslintrc
file to webpack/ so its no longer "up in the tree"
and picked up by running eslint in engines/ directory