### PR TITLE
add foreman-ansible-modules job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-ansible-modules-pr-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-ansible-modules-pr-test.yaml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: 'foreman-ansible-modules-pr-test'
+    project-type: 'pipeline'
+    sandbox: true
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-ansible-modules
+    triggers:
+      - github-pull-request:
+          org-list:
+            - theforeman
+          status-context: 'integration'
+          trigger-phrase: '.*\[test integration\].*'
+          permit-all: true
+          github-hooks: true
+          allow-whitelist-orgs-as-admins: true
+          status-add-test-results: true
+          cancel-builds-on-update: true
+    dsl:
+      !include-raw:
+        - pipelines/test/containers.groovy
+        - ../theforeman.org/pipelines/lib/duffy.groovy
+        - ../theforeman.org/pipelines/lib/ansible.groovy
+        - ../theforeman.org/pipelines/lib/openshift.groovy
+        - ../theforeman.org/pipelines/lib/folderChanged.groovy

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/ansible-modules.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/ansible-modules.groovy
@@ -1,0 +1,72 @@
+pipeline {
+    agent { label 'foreman' }
+
+    stages {
+        stage('Setup Environment') {
+            steps {
+                deleteDir()
+                git url: 'https://github.com/theforeman/forklift.git'
+            }
+        }
+        stage('Provision Node') {
+            steps {
+
+                provision()
+
+            }
+        }
+        stage('Setup Openshift') {
+            steps {
+
+                containerPlaybook('tools/install-minishift.yml')
+                containerPlaybook('tools/minishift-start.yml')
+
+            }
+        }
+        stage('Copy Forklift') {
+            steps {
+
+                containerPlaybook('tools/install-forklift.yml')
+
+            }
+        }
+        stage('Deploy to Openshift') {
+            steps {
+
+                containerPlaybook('tools/deploy.yml')
+
+            }
+        }
+        stage('Clone foreman-ansible-modules') {
+            steps {
+                deleteDir()
+
+                checkout changelog: true, poll: false, scm: [
+                    $class: 'GitSCM',
+                    branches: [[name: '${ghprbActualCommit}']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [[$class: 'PreBuildMerge', options: [fastForwardMode: 'FF', mergeRemote: 'origin', mergeTarget: '${ghprbTargetBranch}']]],
+                    userRemoteConfigs: [
+                        [refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*', url: 'https://github.com/theforeman/foreman-ansible-modules']
+                    ]
+                ]
+            
+            }
+        }
+        stage('Smoke Tests') {
+            steps {
+                route = getOcRoute('foreman-https')
+                ansibleModulesPlaybook('test/test_playbooks/location.yml', route)
+            }
+        }
+    }
+
+    post {
+        always {
+
+            deprovision()
+            deleteDir()
+
+        }
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/containers.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/containers.groovy
@@ -79,14 +79,3 @@ pipeline {
         }
     }
 }
-
-def containerPlaybook(playbook) {
-    dir('containers') {
-        runPlaybook(
-            playbook: playbook,
-            inventory: cico_inventory('../'),
-            extraVars: ['@vars/remote.yml'],
-            options: ['-b']
-        )
-    }
-}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
@@ -23,3 +23,24 @@ def runPlaybook(args) {
         sh "${command.join(' ')}"
     }
 }
+
+def containerPlaybook(playbook) {
+    dir('containers') {
+        runPlaybook(
+            playbook: playbook,
+            inventory: cico_inventory('../'),
+            extraVars: ['@vars/remote.yml'],
+            options: ['-b']
+        )
+    }
+}
+
+def ansibleModulesPlaybook(playbook, route) {
+    dir('ansible-modules') {
+        runPlaybook(
+            playbook: playbook,
+            inventory: cico_inventory('../'),
+            extraVars: ['@../containers/vars/remote.yml', "foreman_server_url=https://${route}"],
+        )
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/openshift.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/openshift.groovy
@@ -1,0 +1,14 @@
+def getOcRoute(args) {
+    name = args.name
+
+    def command = [
+        "jq -r '.items[] | select(.metadata.name == \"${name}\") | .spec.host'"
+        "oc get routes --output json",
+        
+    ]
+
+    wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
+        hostname = sh ( "${command.join(' ')}" )
+    }
+    hostname
+}


### PR DESCRIPTION
I need to make some changes to `foreman-ansible-modules` to before we merge this so initially, I've just got it testing the foreman_location module until I can show the pipeline is working. How can we test this before merging?