### PR TITLE
Apply the rackspace hostname workaround on systests

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
@@ -41,7 +41,9 @@
                 options:
                   disabled: true
             ansible:
-              playbook: 'playbooks/bats_pipeline_foreman_nightly.yml'
+              playbook:
+                - 'playbooks/rackspace_hostname.yml'
+                - 'playbooks/bats_pipeline_foreman_nightly.yml'
               group: 'bats'
               variables:
                 bats_environment:


### PR DESCRIPTION
Depends on https://github.com/theforeman/forklift/pull/824