### PR TITLE
don't explicitly mention the all group

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
@@ -17,7 +17,6 @@
     - name: 'Write cico inventory'
       copy:
         content: |
-          [all]
           {% for host, value in cico_data.results.hosts.items() %}
           {{ value.hostname }} ansible_fqdn={{ value.hostname }} ansible_ssh_user=root ansible_ssh_private_key_file=~/.ssh/id_rsa ansible_ssh_host={{ value.ip_address }}
           {% endfor %}


### PR DESCRIPTION
the "all" group is created automatically by ansible [1]

and writing it seems to sometimes confuse the task:

    fatal: [localhost]: FAILED! => {"changed": false, "msg": "could not write content temp file: <built-in function all> is not JSON serializable"}

[1] https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html