### PR TITLE
wait up to two hours for the remote jenkins job to complete

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
@@ -77,7 +77,7 @@
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/api/json"
       register: build_job_result
       until: (build_job_result.json is defined) and (build_job_result.json.result == 'SUCCESS' or build_job_result.json.result == 'FAILURE')
-      retries: 280
+      retries: 360
       delay: 20
 
     - fail:


### PR DESCRIPTION
360 retries at 20 seconds interval = 7200 seconds, aka 2 hours