### PR TITLE
archive ci.centos.org data for easier job failure analysis

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/duffy.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/duffy.groovy
@@ -4,6 +4,9 @@ def provision() {
 
   	dir('foreman-infra/ci/centos.org/ansible') {
         runPlaybook(playbook: 'provision.yml')
+        archiveArtifacts artifacts: cico_data.json
+        archiveArtifacts artifacts: cico_inventory
+        archiveArtifacts artifacts: ssh_config
     }
 }
 


### PR DESCRIPTION
sometimes jobs fail because the cico data we got is incomplete/empty, this makes it easier to spot such failures

example failure, where it *seems* we got an empty response: https://ci.centos.org/job/foreman-katello-nightly-test/76/