### PR TITLE
try harder to get a node from cico and fail properly

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
@@ -3,11 +3,24 @@
   vars:
     api_key: "{{ lookup('file', '~/duffy.key') }}"
   tasks:
-    - name: 'Get list of nodes'
+    - name: 'Get a new node'
       cico:
         action: get
         api_key: "{{ api_key }}"
       register: cico_data
+
+    - name: 'Retry geting list of nodes'
+      cico:
+        action: list
+        api_key: "{{ api_key }}"
+        ssid: "{{ cico_data.results.ssid }}"
+      register: cico_data
+      when: len(cico_data.results.hosts) == 0
+
+    - name: 'Fail if no hosts returned'
+      fail:
+        msg: 'Could not get hosts from ci.centos.org'
+      when: len(cico_data.results.hosts) == 0
 
     - name: 'Write cico data locally'
       copy:


### PR DESCRIPTION
sometimes, cico returns

    {"message": "Requested servers successfully", "hosts": {}, "ssid": "012345679"}

with the hosts list being empty. This makes the data useless for further
processing. Try to get a list of hosts from cico again and if that
returns no hosts too, properly fail inside the playbook, instead of
writing an empty inventory and then failing in the next steps of the
pipeline.