### PR TITLE
Update `stable` manual version to `1.19`

### DIFF
--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -11,7 +11,7 @@
 #          certs have to exist, so keep SSL vhosts disabled until the certs are present via the HTTP
 #          vhost and only then enable the SSL vhosts.
 class web(
-  String $stable = '1.18',
+  String $stable = '1.19',
   String $latest = '1.19',
   String $next = '1.20',
   Hash[String, Hash] $htpasswds = {},


### PR DESCRIPTION
There is no copy for 1.20 yet, so I've left `latest` and `next` as is.