### PR TITLE
Fix pbuilder cleaning

### DIFF
--- a/puppet/modules/debian/manifests/pbuilder_setup.pp
+++ b/puppet/modules/debian/manifests/pbuilder_setup.pp
@@ -43,7 +43,7 @@ define debian::pbuilder_setup (
   file { "/etc/cron.d/cleanup-${name}":
     ensure  => file,
     mode    => '0644',
-    content => "11 5 * * * root find /var/cache/pbuilder/${name}/result/* -mtime +1 -delete\n",
+    content => "11 5 * * * root find /var/cache/pbuilder/${name}/result -mindepth 1 -mtime +1 -delete\n",
   }
 
 }


### PR DESCRIPTION
The subdirectories of result might not exist. This causes an error when cleaning. The mindepth ensures the directory itself isn't removed.