### PR TITLE
Revert "Apply the rackspace hostname workaround on systests"

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
@@ -41,9 +41,7 @@
                 options:
                   disabled: true
             ansible:
-              playbook:
-                - 'playbooks/rackspace_hostname.yml'
-                - 'playbooks/bats_pipeline_foreman_nightly.yml'
+              playbook: 'playbooks/bats_pipeline_foreman_nightly.yml'
               group: 'bats'
               variables:
                 bats_environment:


### PR DESCRIPTION
Rackspace reports the issue should be solved with the newest version of nova-agent and the workaround is no longer needed.

This reverts commit 4ac6f4c69b727154049e110bcadf2056e45b12c0.