### PR TITLE
merge both properties entries for packaging-rpm-test

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging/foreman-packaging-rpm-pr-test.yaml
@@ -5,13 +5,12 @@
     properties:
       - github:
           url: https://github.com/theforeman/foreman-packaging
-    triggers:
-      - github_pr_rpm:
-          context: 'rpm'
-    properties:
       - build-discarder:
           days-to-keep: 30
           artifact-days-to-keep: 30
+    triggers:
+      - github_pr_rpm:
+          context: 'rpm'
     dsl:
       !include-raw:
         - pipelines/test/rpm_packaging.groovy


### PR DESCRIPTION
otherwise the second entry wins, and the data from the first one is lost