### PR TITLE
Call setup_obal explicitly

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/obal.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/obal.groovy
@@ -11,8 +11,6 @@ def obal(args) {
 
     writeYaml file: extra_vars_file, data: extra_vars
 
-    setup_obal()
-
     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
         withEnv(['ANSIBLE_FORCE_COLOR=true', "PYTHONPATH=${pwd()}/obal"]) {
             sh "python -m obal ${args.action} ${packages} ${tags} -e @${extra_vars_file}"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanClientRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanClientRelease.groovy
@@ -22,6 +22,7 @@ pipeline {
             agent { label 'el' }
             steps {
                 git url: "https://github.com/theforeman/foreman-packaging", branch: "rpm/develop"
+                setup_obal()
             }
         }
         stage('Repoclosure') {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman_packaging_release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman_packaging_release.groovy
@@ -49,6 +49,7 @@ pipeline {
             }
             steps {
 
+                setup_obal()
                 obal(
                     action: 'release',
                     packages: packages_to_build

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/rubygemRPMNightlyRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/rubygemRPMNightlyRelease.groovy
@@ -44,6 +44,7 @@ pipeline {
             steps {
                 dir('foreman-packaging') {
                     git(url: 'https://github.com/theforeman/foreman-packaging', branch: 'rpm/develop')
+                    setup_obal()
                     obal(action: "nightly", extraVars: obalExtraVars, packages: package_name)
                 }
             }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tfmROR52.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/tfmROR52.groovy
@@ -22,6 +22,7 @@ pipeline {
                     ]
                 ])
 
+                setup_obal()
             }
         }
         stage('Find packages') {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/tfmROR51.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/tfmROR51.groovy
@@ -16,6 +16,7 @@ pipeline {
 
                 deleteDir()
                 ghprb_git_checkout()
+                setup_obal()
 
             }
         }


### PR DESCRIPTION
The git checkouts on each call to obal() will fail if within a
parallel block. Let's make this explicit until we switch to the
Obal package.