### PR TITLE
Ensure variables are scoped to instance of obal method

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/obal.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/obal.groovy
@@ -2,9 +2,9 @@ def obal(args) {
     def timestamp = new Date().getTime()
     def extra_vars_file = 'extra_vars-' + timestamp.toString() + '.yaml'
 
-    tags = args.tags ? "--tags ${args.tags}" : ""
-    extra_vars = args.extraVars ?: [:]
-    packages = args.packages
+    def tags = args.tags ? "--tags ${args.tags}" : ""
+    def extra_vars = args.extraVars ?: [:]
+    def packages = args.packages
     if (packages instanceof String[]) {
         packages = packages.join(' ')
     }


### PR DESCRIPTION
In a parallel run, these variables can end up evaluating to the last
value passed in.