### PR TITLE
Drop Fedora rewrite rule fc ->

### DIFF
--- a/puppet/modules/web/templates/yum.conf.erb
+++ b/puppet/modules/web/templates/yum.conf.erb
@@ -1,11 +1,3 @@
-<Directory /var/www/vhosts/yum/htdocs>
-  <IfModule mod_rewrite.c>
-    # rewrite /fc42/ -> /f42/
-    RewriteEngine On
-    RewriteRule (.*)/fc(\d+)/(.*) $1/f$2/$3
-  </IfModule>
-</Directory>
-
 # Prevent top-level repodata file being cached
 <IfModule mod_expires.c>
   <Files "repomd.xml">


### PR DESCRIPTION
This will allow whatever is copied from koji to be used directly
instead of providing this rewrite that can add confusion.