### PR TITLE
Move build_job_description to foreman_infra.groovy

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/duffy.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/duffy.groovy
@@ -43,15 +43,3 @@ def duffy_ssh(command, box_name, relative_dir = '') {
 def duffy_scp(file_path, file_dest, box_name, relative_dir = '') {
     color_shell "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r -F ${ssh_config(relative_dir)} ${box_name}:${file_path} ${file_dest}"
 }
-
-def set_job_build_description() {
-    def build_description = ""
-    def files_list = sh(script: "ls jobs/ -1", returnStdout: true).trim().split()
-
-    for (i = 0; i < files_list.size(); i++) {
-       link = readFile("jobs/${files_list[i]}")
-       build_description += "<a href=\"${link}\">${files_list[i]}</a><br/>"
-    }
-
-    currentBuild.description = build_description
-}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman_infra.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman_infra.groovy
@@ -5,3 +5,15 @@ void git_clone_foreman_infra(args = [:]) {
         git url: 'https://github.com/theforeman/foreman-infra'
     }
 }
+
+def set_job_build_description() {
+    def build_description = ""
+    def files_list = sh(script: "ls jobs/ -1", returnStdout: true).trim().split()
+
+    for (i = 0; i < files_list.size(); i++) {
+       link = readFile("jobs/${files_list[i]}")
+       build_description += "<a href=\"${link}\">${files_list[i]}</a><br/>"
+    }
+
+    currentBuild.description = build_description
+}


### PR DESCRIPTION
To fix nightly and prevent jobs on the ci.theforeman.org side form having to include all of `duffy.groovy` into their pipeline when its all unused on that side.