### PR TITLE
Set Kafo RVM version to 2.0.0

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_kafo_pull_request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_kafo_pull_request.yaml
@@ -20,7 +20,7 @@
           type: user-defined
           name: ruby
           values:
-          - '2.0'
+          - '2.0.0'
           - '2.1'
           - '2.2'
           - '2.3'


### PR DESCRIPTION
Hopefully this fixes the errors from https://ci.theforeman.org/job/test_kafo_master_pull_request/404/puppet=4.10,ruby=2.0/console

  To install do: 'rvm install "ruby-2.0.0-p648"'