### PR TITLE
Skip Ubuntu tests in release_nightly_test_deb

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_test_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_test_deb.yaml
@@ -14,8 +14,9 @@
           name: os
           values:
           - debian9
-          - ubuntu1604
-          - ubuntu1804
+          # TODO: nova provisioning is broken on rackspace
+          #- ubuntu1604
+          #- ubuntu1804
       - axis:
           type: label-expression
           name: label


### PR DESCRIPTION
Currently nova provisioning is broken on rackspace for Ubuntu. It doesn't set the fqdn correctly which makes the installer fail. This means we haven't had nightlies for a long time. While this isn't pretty, it's better than having no nightlies at all.