### PR TITLE
Use extra vars from command line for centos jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -40,6 +40,7 @@ pipeline {
                     playbook: 'foreman-infra/ci/centos.org/ansible/fetch_debug_files.yml',
                     inventory: cico_inventory('./'),
                     extraVars: ["workspace": "${env.WORKSPACE}/debug"],
+                    commandLineExtraVars: true,
                     options: ['-b']
                   )
             }


### PR DESCRIPTION
Tested and worked as a solution to limit to ci.centos use. There really isn't any sensitive information to worry about but I can update to the same pattern there if you want.