### PR TITLE
Pin bundler to < 2.0

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -11,7 +11,7 @@ def gemset(name = null) {
 
 def configureRVM(ruby = '2.0', name = '') {
     emptyGemset(ruby, name)
-    withRVM(['gem install bundler'], ruby, name)
+    withRVM(["gem install bundler -v '< 2.0'"], ruby, name)
 }
 
 def emptyGemset(ruby = '2.0', name = '') {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/deploy_web.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/deploy_web.sh
@@ -12,7 +12,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 bundle install --jobs=5 --retry=5
 
 # compile site on slave

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/pkg_generate_source.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/pkg_generate_source.sh
@@ -10,7 +10,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 bundle install --jobs=5 --retry=5
 
 PAGER=/bin/cat git log | head -n 50

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/kafo.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/kafo.sh
@@ -14,7 +14,7 @@ set -x
 
 # Update any gems from the global gemset
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # rename axis for Gemfile env var
 export PUPPET_VERSION=$puppet

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/proxy.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/proxy.sh
@@ -15,7 +15,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Puppet environment
 sed -i "/^\s*gem.*puppet/ s/\$/, '~> $puppet'/" $APP_ROOT/bundler.d/puppet.rb

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_bastion_assets_precompile.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_bastion_assets_precompile.sh
@@ -41,7 +41,7 @@ gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Now let's introduce the plugin
 echo "gemspec :path => '${PLUGIN_ROOT}', :development_group => :bastion_dev" >> bundler.d/Gemfile.local.rb

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -16,7 +16,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent
 bundle install --without=development --jobs=5 --retry=5

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli.sh
@@ -11,7 +11,7 @@ rvm gemset empty --force
 set -x
 
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 bundle install --without=development --jobs=5 --retry=5
 bundle exec rake pkg:generate_source ci:setup:minitest test TESTOPTS="-v"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman.sh
@@ -11,7 +11,7 @@ rvm gemset empty --force
 set -x
 
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Link hammer_cli from github
 echo 'gem "hammer_cli", :github => "theforeman/hammer-cli"' > Gemfile.local

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman_discovery.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman_discovery.sh
@@ -7,7 +7,7 @@ gemset=$(echo ${JOB_NAME} | cut -d/ -f1)-${EXECUTOR_NUMBER}
 rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Link hammer_cli from github
 echo 'gem "hammer_cli", :github => "theforeman/hammer-cli"' > Gemfile.local

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman_pull_request.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_foreman_pull_request.sh
@@ -11,7 +11,7 @@ rvm gemset empty --force
 set -x
 
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Link hammer_cli from github
 echo 'gem "hammer_cli", :github => "theforeman/hammer-cli"' > Gemfile.local

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_pull_request.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_hammer_cli_pull_request.sh
@@ -11,7 +11,7 @@ rvm gemset empty --force
 set -x
 
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 bundle install --without development --jobs=5 --retry=5
 bundle exec rake ci:setup:minitest test TESTOPTS="-v"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_kafo_parsers_master.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_kafo_parsers_master.sh
@@ -12,7 +12,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # rename axis for Gemfile env var
 export PUPPET_VERSION=$puppet

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
@@ -42,7 +42,7 @@ rvm gemset empty --force
 set -x
 
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Now let's introduce the plugin
 echo "gemspec :path => '${PLUGIN_ROOT}', :development_group => :katello_dev" >> bundler.d/Gemfile.local.rb

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -23,7 +23,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 
 set -x
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent
 bundle install --without=development --jobs=5 --retry=5

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_proxy_develop_pr_core.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_proxy_develop_pr_core.sh
@@ -17,7 +17,7 @@ set -x
 
 # Update any gems from the global gemset
 #gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Puppet environment
 sed -i "/^\s*gem.*puppet/ s/\$/, '~> $puppet'/" $APP_ROOT/bundler.d/puppet.rb

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_proxy_develop_pr_rubocop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_proxy_develop_pr_rubocop.sh
@@ -16,7 +16,7 @@ set -x
 
 # Update any gems from the global gemset
 gem update --no-ri --no-rdoc
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 bundle install --with=test --without='development puppet windows bmc' --retry 5 --jobs 5
 bundle exec rake jenkins:rubocop TESTOPTS="-v"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
@@ -18,7 +18,7 @@ rvm use ruby-${ruby}@${gemset} --create
 rvm gemset empty --force
 set -x
 
-gem install bundler --no-ri --no-rdoc
+gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
 # Retry as rubygems (being external to us) can be intermittent
 bundle install --without=development --jobs=5 --retry=5

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -29,7 +29,7 @@
           gemset=$(echo ${{JOB_NAME}} | cut -d/ -f1)-${{EXECUTOR_NUMBER}}
           rvm use ruby-${{ruby}}@${{gemset}} --create
           rvm gemset empty --force
-          gem install bundler --no-ri --no-rdoc
+          gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
           bundle install --without development --jobs=5 --retry=5
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/smart-proxy-plugin.yaml
@@ -13,7 +13,7 @@
           rvm gemset empty --force
           set -x
 
-          gem install bundler --no-ri --no-rdoc
+          gem install bundler -v '< 2.0' --no-ri --no-rdoc
 
           bundle install --retry 5 --jobs 5
           bundle exec rake TESTOPTS="-v"


### PR DESCRIPTION
Bundler 2.0 requires ruby 2.3 and rubygems 3.0 or later, breaking all of
our pipelines. This is a temporary pin to get CI working again until we
figure out which pipelines can be upgraded to the newer version and
which cannot.

Fixes #894