### PR TITLE
Remove organization/location enabling in CI

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
@@ -33,14 +33,6 @@ def addGem() {
 
 def addSettings(settings) {
     sh "cp config/settings.yaml.example config/settings.yaml"
-
-    if (settings['locations']) {
-        sh "sed -i 's/:locations_enabled: false/:locations_enabled: true/' config/settings.yaml"
-    }
-
-    if (settings['organizations']) {
-        sh "sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' config/settings.yaml"
-    }
 }
 
 def configureDatabase(ruby) {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -64,10 +64,6 @@ pipeline {
             steps {
 
                 dir('foreman') {
-                    addSettings([
-                        organizations: true,
-                        locations: true
-                    ])
                     addGem()
                     databaseFile(gemset())
                 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_bastion_assets_precompile.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_bastion_assets_precompile.sh
@@ -31,8 +31,7 @@ cd $APP_ROOT
 # This section is from test_develop, please keep it in sync
 
 # setup basic settings file
-sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
-sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
+cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
 
 # RVM Ruby environment
 . /etc/profile.d/rvm.sh

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_develop.sh
@@ -3,8 +3,7 @@
 APP_ROOT=`pwd`
 
 # setup basic settings file
-sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
-sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
+cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
 
 echo "Setting up RVM environment."
 set +x

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_katello.sh
@@ -28,8 +28,7 @@ cd $APP_ROOT
 mkdir config/settings.plugins.d
 
 # setup basic settings file
-sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
-sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
+cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
 
 echo "Setting up RVM environment."
 set +x

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -10,8 +10,7 @@ cd $APP_ROOT
 # This section is from test_develop, please keep it in sync
 
 # setup basic settings file
-sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
-sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
+cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
 
 echo "Setting up RVM environment."
 set +x

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
@@ -5,8 +5,7 @@ git checkout origin/$old_branch
 APP_ROOT=`pwd`
 
 # setup basic settings file
-sed -e 's/:locations_enabled: false/:locations_enabled: true/' $APP_ROOT/config/settings.yaml.example > $APP_ROOT/config/settings.yaml
-sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' $APP_ROOT/config/settings.yaml
+cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
 
 echo "Setting up RVM environment."
 set +x

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -20,8 +20,7 @@
           cd ${{APP_ROOT}}
 
           # setup basic settings file
-          sed -e 's/:locations_enabled: false/:locations_enabled: true/' ${{APP_ROOT}}/config/settings.yaml.example > ${{APP_ROOT}}/config/settings.yaml
-          sed -i 's/:organizations_enabled: false/:organizations_enabled: true/' ${{APP_ROOT}}/config/settings.yaml
+          cp $APP_ROOT/config/settings.yaml.example $APP_ROOT/config/settings.yaml
 
           # RVM Ruby environment
           . /etc/profile.d/rvm.sh

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/systest.yaml
@@ -23,10 +23,6 @@
 
           args=""
 
-          if [[ ${{run_hammer_tests}} == true ]]; then
-            args+=" --foreman-organizations-enabled=true --foreman-locations-enabled=true"
-          fi
-
           if [[ -n "${{db_type}}" ]]; then
             args+=" --foreman-db-type=${{db_type}}"
           fi


### PR DESCRIPTION
Organizations an Locations are now always enabled, no need to manually
enable them in the ci pipelines.