### PR TITLE
fix katello upgrade pipeline

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.10-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.10-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.10']]
+    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.10', 'katello_version_start': '3.9']]
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.8-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.8-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.8']]
+    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.8', 'katello_version_start: '3.7']]
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.9-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.9-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.9']]
+    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.9', 'katello_version_start': '3.8']]
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katelloUpgradeNightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katelloUpgradeNightly.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': 'nightly']]
+    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': 'nightly', 'katello_version_start': '3.10']]
     return playBook
 }


### PR DESCRIPTION
I think this will fix katello upgrade pipelines: `ERROR! vars file vars/katello_{{ katello_version_start }}.yml was not found on the Ansible Controller.`

https://ci.centos.org/view/Foreman/job/foreman-katello-upgrade-3.8-test/29/consoleFull