### PR TITLE
Skip 'intermediate' tag for 3.8 upgrade

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -29,7 +29,8 @@ pipeline {
             steps {
                 script {
                     extra_vars = buildExtraVars(extraVars: playBook['extraVars'])
-                    duffy_ssh("cd forklift && ansible-playbook pipelines/${playBook['pipeline']} -e forklift_state=up ${extra_vars}", 'duffy_box', './')
+                    skip_tags = buildSkipTags(skipTags: playBook['skipTags'])
+                    duffy_ssh("cd forklift && ansible-playbook pipelines/${playBook['pipeline']} -e forklift_state=up ${extra_vars} ${skip_tags}", 'duffy_box', './')
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.8-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.8-upgrade.groovy
@@ -1,4 +1,9 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-centos7'], 'pipeline': 'katello_upgrade_pipeline.yml', 'extraVars': ['katello_version': '3.8']]
+    playBook = [
+                'boxes': ['pipeline-upgrade-centos7'],
+                'pipeline': 'katello_upgrade_pipeline.yml',
+                'extraVars': ['katello_version': '3.8'],
+                'skipTags': ['intermediate']
+               ]
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
@@ -69,3 +69,13 @@ def buildExtraVars(args) {
 
     return extra_vars_string
 }
+
+def buildSkipTags(args) {
+  def skip_tags = args.skipTags ?: []
+
+  if (skip_tags.size() == 0) {
+    return ''
+  }
+
+  return '--skip-tags=' + skip_tags.join(',')
+}


### PR DESCRIPTION
This adds the ability to skip ansible tags when running a playbook - and 3.8 upgrade pipeline has been changed to use the functionality

Forklift counterpart: https://github.com/theforeman/forklift/pull/903