### PR TITLE
only add job link for the currently running job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman_infra.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman_infra.groovy
@@ -6,13 +6,13 @@ void git_clone_foreman_infra(args = [:]) {
     }
 }
 
-def set_job_build_description() {
+def set_job_build_description(job_name) {
     def build_description = ""
-    def files_list = sh(script: "ls jobs/ -1", returnStdout: true).trim().split()
+    def file_name = "jobs/${job_name}"
 
-    for (i = 0; i < files_list.size(); i++) {
-       link = readFile("jobs/${files_list[i]}")
-       build_description += "<a href=\"${link}\">${files_list[i]}</a><br/>"
+    if (fileExists(file_name)) {
+       link = readFile(file_name)
+       build_description += "<a href=\"${link}\">${job_name}</a><br/>"
     }
 
     if (currentBuild.description == null) {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
@@ -49,7 +49,7 @@ pipeline {
             post {
                 always {
                     script {
-                        set_job_build_description()
+                        set_job_build_description("foreman-nightly-test")
                     }
                 }
             }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
@@ -29,6 +29,9 @@ pipeline {
         }
         stage('Install Test') {
             agent { label 'el' }
+            environment {
+                cico_job_name = "foreman-nightly-test"
+            }
 
             steps {
 
@@ -38,9 +41,9 @@ pipeline {
                     runPlaybook(
                         playbook: 'ci/centos.org/ansible/jenkins_job.yml',
                         extraVars: [
-                            "jenkins_job_name": "foreman-nightly-test",
+                            "jenkins_job_name": "${env.cico_job_name}",
                             "jenkins_username": "${env.USERNAME}",
-                            "jenkins_job_link_file": "${env.WORKSPACE}/jobs/foreman-nightly-test"
+                            "jenkins_job_link_file": "${env.WORKSPACE}/jobs/${env.cico_job_name}"
                         ],
                         sensitiveExtraVars: ["jenkins_password": "${env.PASSWORD}"]
                     )
@@ -49,7 +52,7 @@ pipeline {
             post {
                 always {
                     script {
-                        set_job_build_description("foreman-nightly-test")
+                        set_job_build_description("${env.cico_job_name}")
                     }
                 }
             }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
@@ -59,7 +59,7 @@ pipeline {
                     post {
                         always {
                             script {
-                                set_job_build_description()
+                                set_job_build_description("foreman-katello-nightly-test")
                             }
                         }
                     }
@@ -86,7 +86,7 @@ pipeline {
                     post {
                         always {
                             script {
-                                set_job_build_description()
+                                set_job_build_description("foreman-katello-upgrade-nightly-test")
                             }
                         }
                     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
@@ -41,6 +41,10 @@ pipeline {
 
                 stage('Install test') {
                     agent { label 'el' }
+                    environment {
+                        cico_job_name = "foreman-katello-nightly-test"
+                    }
+
                     steps {
                         git_clone_foreman_infra()
 
@@ -48,9 +52,9 @@ pipeline {
                             runPlaybook(
                                 playbook: 'ci/centos.org/ansible/jenkins_job.yml',
                                 extraVars: [
-                                    "jenkins_job_name": "foreman-katello-nightly-test",
+                                    "jenkins_job_name": "${env.cico_job_name}",
                                     "jenkins_username": "foreman",
-                                    "jenkins_job_link_file": "${env.WORKSPACE}/jobs/foreman-katello-nightly-test"
+                                    "jenkins_job_link_file": "${env.WORKSPACE}/jobs/${env.cico_job_name}"
                                 ],
                                 sensitiveExtraVars: ["jenkins_password": "${env.PASSWORD}"]
                             )
@@ -59,7 +63,7 @@ pipeline {
                     post {
                         always {
                             script {
-                                set_job_build_description("foreman-katello-nightly-test")
+                                set_job_build_description("${env.cico_job_name}")
                             }
                         }
                     }
@@ -67,6 +71,10 @@ pipeline {
 
                 stage('Upgrade test') {
                     agent { label 'el' }
+                    environment {
+                        cico_job_name = "foreman-katello-upgrade-nightly-test"
+                    }
+
                     steps {
                         git_clone_foreman_infra()
                         sleep(5) //See https://bugs.centos.org/view.php?id=14920
@@ -75,9 +83,9 @@ pipeline {
                             runPlaybook(
                                 playbook: 'ci/centos.org/ansible/jenkins_job.yml',
                                 extraVars: [
-                                    "jenkins_job_name": "foreman-katello-upgrade-nightly-test",
+                                    "jenkins_job_name": "${env.cico_job_name}",
                                     "jenkins_username": "foreman",
-                                    "jenkins_job_link_file": "${env.WORKSPACE}/jobs/foreman-katello-upgrade-nightly-test"
+                                    "jenkins_job_link_file": "${env.WORKSPACE}/jobs/${env.cico_job_name}"
                                 ],
                                 sensitiveExtraVars: ["jenkins_password": "${env.PASSWORD}"]
                             )
@@ -86,7 +94,7 @@ pipeline {
                     post {
                         always {
                             script {
-                                set_job_build_description("foreman-katello-upgrade-nightly-test")
+                                set_job_build_description("${env.cico_job_name}")
                             }
                         }
                     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/ci_centos_integration_test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/ci_centos_integration_test.groovy
@@ -1,5 +1,8 @@
 pipeline {
     agent { label 'el' }
+    environment {
+        cico_job_name = "foreman-ci-centos-simple-test"
+    }
 
     options {
         timestamps()
@@ -18,9 +21,9 @@ pipeline {
                     runPlaybook(
                         playbook: 'ci/centos.org/ansible/jenkins_job.yml',
                         extraVars: [
-                            "jenkins_job_name": "foreman-ci-centos-simple-test",
+                            "jenkins_job_name": "${env.cico_job_name}",
                             "jenkins_username": "foreman",
-                            "jenkins_job_link_file": "${env.WORKSPACE}/jobs/foreman-ci-centos-simple-test"
+                            "jenkins_job_link_file": "${env.WORKSPACE}/jobs/${cico_job_name}"
                         ],
                         sensitiveExtraVars: ["jenkins_password": "${env.PASSWORD}"]
                     )
@@ -30,10 +33,10 @@ pipeline {
                     runPlaybook(
                         playbook: 'ci/centos.org/ansible/jenkins_job.yml',
                         extraVars: [
-                            "jenkins_job_name": "foreman-ci-centos-simple-test",
+                            "jenkins_job_name": "${env.cico_job_name}",
                             "jenkins_username": "foreman",
                             "jenkins_password": "${env.PASSWORD}",
-                            "jenkins_job_link_file": "${env.WORKSPACE}/jobs/foreman-ci-centos-simple-test-2"
+                            "jenkins_job_link_file": "${env.WORKSPACE}/jobs/${env.cico_job_name}-2"
                         ],
                         sensitiveExtraVars: ["jenkins_password": "${env.PASSWORD}"]
                     )
@@ -42,8 +45,8 @@ pipeline {
             post {
                 always {
                     script {
-                        set_job_build_description("foreman-ci-centos-simple-test")
-                        set_job_build_description("foreman-ci-centos-simple-test-2")
+                        set_job_build_description("${env.cico_job_name}")
+                        set_job_build_description("${env.cico_job_name}-2")
                     }
                 }
             }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/ci_centos_integration_test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/ci_centos_integration_test.groovy
@@ -42,7 +42,8 @@ pipeline {
             post {
                 always {
                     script {
-                        set_job_build_description()
+                        set_job_build_description("foreman-ci-centos-simple-test")
+                        set_job_build_description("foreman-ci-centos-simple-test-2")
                     }
                 }
             }


### PR DESCRIPTION
when a pipeline runs multiple steps in parallel on the same node, each
step gets an unique workspace (jobname@XXX for all but the first run).
this means that when we write the remote job details to the workspace,
we might not overwrite any pre-existing files in there.

this leads to jobs with multiple links like seen in [1], which is
confusing.
let's be more explicit and only add one link at at time to the
description.

[1] https://ci.theforeman.org/job/katello-nightly-rpm-pipeline/659/