### PR TITLE
 use git diff instead of find to find the old and new specfiles

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rpm_packaging.groovy
@@ -6,8 +6,20 @@ def update_build_description_from_packages(packages_to_build) {
     currentBuild.description = build_description
 }
 
+def diff_filter(range, filter, path) {
+    return sh(returnStdout: true, script: "git diff ${range} --name-only --diff-filter=${filter} -- '${path}'").trim()
+}
+
+def find_added_or_changed_files(diff_range, path) {
+    return diff_filter(diff_range, 'ACMRTUXB', path)
+}
+
+def find_deleted_files(diff_range, path) {
+    return diff_filter(diff_range, 'D', path)
+}
+
 def find_changed_packages(diff_range) {
-    def changed_packages = sh(returnStdout: true, script: "git diff ${diff_range} --name-only --diff-filter=ACMRTUXB -- 'packages/**.spec'").trim()
+    def changed_packages = find_added_or_changed_files(diff_range, 'packages/**.spec')
 
     if (changed_packages) {
         changed_packages = sh(returnStdout: true, script: "echo '${changed_packages}' | xargs dirname | xargs -n1 basename |sort -u").trim()

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
@@ -74,17 +74,16 @@ pipeline {
 
 
                         if (old_spec_path) {
-                            sh "git checkout origin/${env.ghprbTargetBranch}"
-                            old_version = query_rpmspec(old_spec_path, '%{VERSION}')
-                            old_release = query_rpmspec(old_spec_path, '%{RELEASE}')
-                            sh "git checkout -"
-
                             new_spec_path = find_added_or_changed_files("origin/${env.ghprbTargetBranch}", spec_pattern)
-
                             if (old_spec_path != new_spec_path) {
                               continue
                             }
 
+                            sh "git checkout origin/${env.ghprbTargetBranch}"
+                            old_version = query_rpmspec(old_spec_path, '%{VERSION}')
+                            old_release = query_rpmspec(old_spec_path, '%{RELEASE}')
+
+                            sh "git checkout -"
                             new_version = query_rpmspec(new_spec_path, '%{VERSION}')
                             new_release = query_rpmspec(new_spec_path, '%{RELEASE}')
 


### PR DESCRIPTION
* introduce more wrappers for git diff and finding of changed files
* use git diff instead of find to find the old and new specfiles
  using find might find the wrong spec file as we sometimes have multiple packages with the same spec name
* move old vs new path check to the begining of the test
