### PR TITLE
Disable concurrent hammer builds

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/rubygemRPMNightlyRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/rubygemRPMNightlyRelease.groovy
@@ -25,7 +25,6 @@ pipeline {
     options {
         timestamps()
         timeout(time: 2, unit: 'HOURS')
-        disableConcurrentBuilds()
         ansiColor('xterm')
     }
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/hammer-cli-katello-master-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/hammer-cli-katello-master-release.yaml
@@ -1,6 +1,7 @@
 - job:
     name: hammer-cli-katello-master-release
     project-type: pipeline
+    concurrent: false
     sandbox: false
     triggers:
       - github


### PR DESCRIPTION
While it has disableConcurrentBuilds, it doesn't appear to actually apply this because we still see concurrent jobs. Though not 100%:

![screenshot_2019-01-28 hammer-cli-katello-master-release jenkins](https://user-images.githubusercontent.com/155810/51838957-16c17b00-2308-11e9-8fd0-d2369a9a3cb8.png)