### PR TITLE
Fix the smart-proxy-develop pipelines

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/smart-proxy-develop-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/smart-proxy-develop-release.yaml
@@ -5,8 +5,6 @@
     properties:
       - github:
           url: 'https://github.com/theforeman/smart-proxy'
-    triggers:
-      - github
     parameters:
       - string:
           name: git_ref

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/smart-proxy-develop-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/smart-proxy-develop-test.yaml
@@ -1,7 +1,7 @@
 - job:
     name: smart-proxy-develop-test
     project-type: pipeline
-    concurrent: true
+    concurrent: false
     properties:
       - github:
           url: https://github.com/theforeman/smart-proxy


### PR DESCRIPTION
The testing job shouldn't be concurrent. There should also not be a github trigger on the release job since the test job takes care of that.