### PR TITLE
fix the selection of "old path"

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rpm_packaging.groovy
@@ -18,6 +18,10 @@ def find_deleted_files(diff_range, path) {
     return diff_filter(diff_range, 'D', path)
 }
 
+def find_changed_files(diff_range, path) {
+    return diff_filter(diff_range, 'M', path)
+}
+
 def find_changed_packages(diff_range) {
     def changed_packages = find_added_or_changed_files(diff_range, 'packages/**.spec')
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
@@ -69,7 +69,7 @@ pipeline {
 
                         old_spec_path = find_deleted_files("origin/${env.ghprbTargetBranch}", spec_pattern)
                         if (! old_spec_path) {
-                            old_spec_path = find_added_or_changed_files("origin/${env.ghprbTargetBranch}", spec_pattern)
+                            old_spec_path = find_changed_files("origin/${env.ghprbTargetBranch}", spec_pattern)
                         }
 
 


### PR DESCRIPTION
the old logic would also find the newly added path, but we actually only
need to look for "deleted" or "changed" files, the "added" ones can
never be "old_path"