### PR TITLE
don't serve freight's .refs folder via http and rsync

### DIFF
--- a/puppet/modules/freight/manifests/user.pp
+++ b/puppet/modules/freight/manifests/user.pp
@@ -68,6 +68,10 @@ define freight::user (
       headers => 'Set Cache-Control "public, max-age=120"',
     },
     {
+      path    => "${webdir}/dists/*/.refs/",
+      deny    => 'from all',
+    },
+    {
       path    => "${webdir}/pool",
       headers => 'Set Cache-Control "public, max-age=2592000"',
     },
@@ -112,6 +116,7 @@ define freight::user (
     uid             => 'nobody',
     gid             => 'nobody',
     max_connections => 5,
+    exclude         => ['/dists/*/.refs/'],
   }
   file { "${webdir}/HEADER.html":
     ensure  => file,


### PR DESCRIPTION
freight uses a .refs folder underneath `dists/<name>-<time>/` to keep
track of "still referenced" debs for housekeeping of `pool/`.
As the timestamp changes every time freight runs, simple mirroring tools
(like wget or rsync) will think these files are new and re-download them
every time, producing more traffic than needed.
These files are internal to freight and not used or referenced in the
repository metadata, so no real Debian client will ever try to access
them. Thus we can just safely exlude them from being transferred save a
lot of traffic.

This commit should save us about $600-700 of traffic each month.