### PR TITLE
poin to rsync.tfm.o not to stagingdeb.tfm.o in rsync url

### DIFF
--- a/puppet/modules/freight/files/stagingdeb-HEADER.html
+++ b/puppet/modules/freight/files/stagingdeb-HEADER.html
@@ -13,7 +13,7 @@ So if you specified 'ares' as the github repo, and 'wheezy' as the distro, your 
 
 <p><strong>deb http://stagingdeb.theforeman.org/ plugins ares</strong></p>
 
-<p>This repo is also available over rsync at <code>rsync://stagingdeb.theforeman.org/stagingdeb</code>.</p>
+<p>This repo is also available over rsync at <code>rsync://rsync.theforeman.org/stagingdeb</code>.</p>
 
 <p>Enjoy</p>
 </body>


### PR DESCRIPTION
stagingdeb points to Fastly and that does not offer rsync