### PR TITLE
Reintroduce the quiet period on foreman-develop-test

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/foreman-develop-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/foreman-develop-test.yaml
@@ -1,6 +1,9 @@
 - job:
     name: foreman-develop-test
     project-type: pipeline
+    quiet-period: 2700
+    properties:
+      - github_foreman
     concurrent: false
     triggers:
       - github


### PR DESCRIPTION
Previously we had a 45 minute quiet period. This ensured we didn't queue up too many nightly builds, for exampe when someone was merging multiple changes.

It also sets the github properties so you get the proper Github links.