### PR TITLE
Remove the reverse dependency on the installer

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/pipeline/foreman-nightly-rpm-pipeline.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/pipeline/foreman-nightly-rpm-pipeline.yaml
@@ -3,10 +3,6 @@
     project-type: pipeline
     triggers:
       - timed: 'H 21 * * *'
-      - reverse:
-          jobs:
-            - foreman-installer-develop-release
-          result: success
     dsl:
       !include-raw:
         - pipelines/release/foremanRelease.groovy


### PR DESCRIPTION
We added this dependency when the installer was split over 2 repositories. This was intended to keep them closer in sync.

Now that it's only in the foreman repository, this isn't really needed anymore.

The effect is that it really does become a nightly again, which will reduce the spam on Discourse. That was increased because we built an installer for every merge to foreman-packaging.