### PR TITLE
Modify foreman develop release timeout

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -6,7 +6,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 3, unit: 'HOURS')
         ansiColor('xterm')
     }
 


### PR DESCRIPTION
Deb releases sometimes take more than 2 hours, causing the pipeline to
timeout.