### PR TITLE
Seperate nightly arm builds and make them non-blocking

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_build_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_build_deb.yaml
@@ -12,6 +12,7 @@
           predefined-parameters: |
             repoowner=theforeman
             project=${project}
+            onlyarch=x86
             onlyos=all
             repo=develop
             version=nightly
@@ -19,6 +20,18 @@
             nightly_jenkins_job=${jenkins_job}
             nightly_jenkins_job_id=${jenkins_job_id}
           block: true
+        - project: packaging_build_deb_coreproject
+          predefined-parameters: |
+            repoowner=theforeman
+            project=${project}
+            onlyarch=armv8
+            onlyos=all
+            repo=develop
+            version=nightly
+            gitrelease=true
+            nightly_jenkins_job=${jenkins_job}
+            nightly_jenkins_job_id=${jenkins_job_id}
+          block: false
     parameters:
       - string:
           name: project


### PR DESCRIPTION
Following the discussion in https://community.theforeman.org/t/dropping-arm-packages/12941, I'm opening this as a first stage. If we agree to drop arm from nightlies completely we can get rid of the second builder.