### PR TITLE
Drop arm builds from nightlies

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_build_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_build_deb.yaml
@@ -12,6 +12,7 @@
           predefined-parameters: |
             repoowner=theforeman
             project=${project}
+            onlyarch=x86
             onlyos=all
             repo=develop
             version=nightly


### PR DESCRIPTION
This is an alternative to GH-961, dropping arm completely from nightlies.