### PR TITLE
Don't trigger release_nightly_build_deb in test_develop

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/test_foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/test_foreman.groovy
@@ -172,16 +172,6 @@ pipeline {
         stage('packaging') {
             steps {
                 build(
-                    job: 'release_nightly_build_deb',
-                    propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'project', value: 'foreman'),
-                        string(name: 'jenkins_job', value: env.JOB_NAME),
-                        string(name: 'jenkins_job_id', value: env.BUILD_ID)
-                    ]
-                )
-                build(
                     job: 'foreman-develop-release',
                     propagate: false,
                     wait: false,


### PR DESCRIPTION
The job `foreman-develop-release` also triggers `release_nightly_build_deb`. This causes duplicate builds and greatly increases the load on our infra.