### PR TITLE
Remove scl-sclo in repoclosure checks

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanPluginsRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanPluginsRelease.groovy
@@ -168,7 +168,6 @@ void repoclosure(repo, dist, additions = []) {
             "-l ${dist}-epel",
             "-l ${dist}-extras",
             "-l ${dist}-scl",
-            "-l ${dist}-scl-sclo",
             "-l ${dist}-puppet-5"
         ]
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanRelease.groovy
@@ -101,7 +101,6 @@ void repoclosure(repo, dist, additions = []) {
             "-l el${dist}-epel",
             "-l el${dist}-extras",
             "-l el${dist}-scl",
-            "-l el${dist}-scl-sclo",
             "-l el${dist}-puppet-5"
         ]
 

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.10.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.10.groovy
@@ -107,7 +107,6 @@ void repoclosure(repo, dist, additions = []) {
             "-l ${dist}-epel",
             "-l ${dist}-extras",
             "-l ${dist}-scl",
-            "-l ${dist}-scl-sclo",
             "-l ${dist}-puppet-5",
             "-l ${dist}-subscription-manager",
             "-l ${dist}-qpid",

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.9.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.9.groovy
@@ -101,7 +101,6 @@ void repoclosure(repo, dist, additions = []) {
             "-l ${dist}-epel",
             "-l ${dist}-extras",
             "-l ${dist}-scl",
-            "-l ${dist}-scl-sclo",
             "-l ${dist}-puppet-5",
             "-l ${dist}-subscription-manager",
             "-l ${dist}-qpid",

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
@@ -138,7 +138,6 @@ void repoclosure(repo, dist, additions = []) {
             "-l ${dist}-epel",
             "-l ${dist}-extras",
             "-l ${dist}-scl",
-            "-l ${dist}-scl-sclo",
             "-l ${dist}-puppet-5",
             "-l ${dist}-katello-pulp-nightly",
             "-l ${dist}-katello-candlepin-nightly"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_repoclosure.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_repoclosure.sh
@@ -45,7 +45,7 @@ if [ -n "${copr_lookasides}" ]; then
 fi
 
 predefined_lookaside=""
-predefined_lookasides="${predefined_lookasides} base updates extras epel scl scl-sclo puppet-5"
+predefined_lookasides="${predefined_lookasides} base updates extras epel scl puppet-5"
 if [[ -n $predefined_lookasides ]]; then
   lookaside_repos=$(echo $predefined_lookasides | tr "," "\n")
 


### PR DESCRIPTION
The scl-sclo repository was removed in 1.20.