### PR TITLE
Refactor mashing to use single scripts with parameters

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/client/1.21.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/client/1.21.groovy
@@ -17,7 +17,7 @@ pipeline {
             agent { label 'sshkey' }
 
             steps {
-                mash("foreman-client-mash-split-${foreman_version}.py")
+                mash("foreman-client-mash-split.py", env.foreman_version)
             }
         }
         stage('Repoclosure') {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.10.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.10.groovy
@@ -18,7 +18,7 @@ pipeline {
 
             steps {
 
-                mash("katello-mash-split-3.10.py")
+                mash("katello-mash-split.py", "3.10")
 
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.11.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.11.groovy
@@ -18,7 +18,7 @@ pipeline {
 
             steps {
 
-                mash("katello-mash-split-3.11.py")
+                mash("katello-mash-split.py", "3.11")
 
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.12.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/3.12.groovy
@@ -18,7 +18,7 @@ pipeline {
 
             steps {
 
-                mash("katello-mash-split-3.12.py")
+                mash("katello-mash-split.py", "3.12")
 
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/katello/nightly.groovy
@@ -18,7 +18,7 @@ pipeline {
 
             steps {
 
-                mash("katello-mash-split.py")
+                mash("katello-mash-split.py", "nightly")
 
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/run_koji_script.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/run_koji_script.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-ssh -o "BatchMode yes" root@koji.katello.org "${script}"
+ssh -o "BatchMode yes" root@koji.katello.org "${script}" "${version}"

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_mash_rpms.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_mash_rpms.yaml
@@ -7,4 +7,8 @@
       - string:
           name: script
           default: 'foreman-mash-split.py'
-          description: 'Change for specific versions, e.g. foreman-mash-split-1.6.py'
+          description: 'Change for different repositories'
+      - string:
+          name: version
+          default: 'nightly'
+          description: 'The version to mash, e.g. nightly or 1.21'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_mash.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_mash.yaml
@@ -8,7 +8,7 @@
     builders:
       - trigger-builds:
         - project: packaging_mash_rpms
-          predefined-parameters: "script=foreman-mash-split-${major_version}.py"
+          predefined-parameters: "script=foreman-mash-split.py version=${major_version}"
           block: true
     publishers:
       - trigger-parameterized-builds:


### PR DESCRIPTION
This is intended to make release work easier. If it's just calling a single script with a version that means we don't need to copy it every release.

This is a draft because the `katello-mash-split-script.py` isn't ready for this.