### PR TITLE
Add a timeout to JJB cronjobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/manifests/config.pp
+++ b/puppet/modules/jenkins_job_builder/manifests/config.pp
@@ -26,7 +26,7 @@ define jenkins_job_builder::config (
   }
 
   cron { "jenkins-jobs-update-${config_name}-delete-old":
-    command     => "jenkins-jobs --conf ${inifile} update --delete-old ${directory}/${config_name} > /var/cache/jjb.xml",
+    command     => "timeout 1h jenkins-jobs --conf ${inifile} update --delete-old ${directory}/${config_name} > /var/cache/jjb.xml",
     hour        => 0,
     minute      => 0,
     environment => 'PATH=/bin:/usr/bin:/usr/sbin',


### PR DESCRIPTION
Sometimes this job hangs and needs to be killed or it'll run forever. Because it first takes a lock, this then blocks other jobs from updating.