### PR TITLE
Fix Debian pipeline

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
@@ -19,7 +19,7 @@ void push_rpms_katello(version) {
 }
 
 void push_debs_direct(os, repo) {
-    sshagent(['repo-sync']) {
+    sshagent(['freight']) {
         sh "ssh freight@deb.theforeman.org deploy ${os} ${repo}"
     }
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-deb.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-deb.groovy
@@ -38,6 +38,7 @@ pipeline {
                             script {
                                 set_job_build_description("${env.cico_job_name}")
                             }
+                            deleteDir()
                         }
                     }
                 }
@@ -68,6 +69,7 @@ pipeline {
                             script {
                                 set_job_build_description("${env.cico_job_name}")
                             }
+                            deleteDir()
                         }
                     }
                 }
@@ -98,10 +100,10 @@ pipeline {
                             script {
                                 set_job_build_description("${env.cico_job_name}")
                             }
+                            deleteDir()
                         }
                     }
                 }
-
             }
         }
         stage('Push DEBs') {
@@ -111,11 +113,6 @@ pipeline {
                 push_debs_direct("stretch", "nightly")
                 push_debs_direct("xenial", "nightly")
                 push_debs_direct("bionic", "nightly")
-            }
-            post {
-                always {
-                    deleteDir()
-                }
             }
         }
     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-deb.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-deb.groovy
@@ -105,7 +105,7 @@ pipeline {
             }
         }
         stage('Push DEBs') {
-            agent { label 'admin && sshkey' }
+            agent { label 'debian' }
 
             steps {
                 push_debs_direct("stretch", "nightly")


### PR DESCRIPTION
* Push using the correct credentials
* Perform cleanup in the correct jobs. These run on different nodes so they should happen inside each stage. Deb pushing doesn't generate any files so no cleanup is needed.