### PR TITLE
Split db:drop into a separate commands

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_upgrade.sh
@@ -30,7 +30,8 @@ bundle install --without=development --jobs=5 --retry=5
 ) > $APP_ROOT/config/database.yml
 
 # Create DB first in development as migrate behaviour can change
-bundle exec rake db:drop db:create db:migrate --trace
+bundle exec rake db:drop --trace
+bundle exec rake db:create db:migrate --trace
 bundle exec rake db:seed --trace
 
 # Back to the pull request


### PR DESCRIPTION
In the past we've seen that db:drop and db:create need to be separate commands because of caches that aren't flushed.