### PR TITLE
Update release jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-installer-develop-test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-installer-develop-test.groovy
@@ -1,0 +1,68 @@
+def commit_hash = ''
+
+pipeline {
+    agent any
+
+    options {
+        timestamps()
+        timeout(time: 2, unit: 'HOURS')
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage("Collect Git Hash") {
+            steps {
+                git(url: 'https://github.com/theforeman/foreman-installer', branch: 'develop')
+                script {
+                    commit_hash = archive_git_hash()
+                }
+            }
+        }
+        stage("test ruby 2.0 & puppet 5") {
+            steps {
+                run_test(ruby: '2.0.0', puppet: '5.5')
+            }
+        }
+        stage("test ruby 2.4 & puppet 5") {
+            steps {
+                run_test(ruby: '2.4', puppet: '5.5')
+            }
+        }
+        stage("test ruby 2.5 & puppet 6") {
+            steps {
+                run_test(ruby: '2.5', puppet: '6.3')
+            }
+        }
+        stage("Release Nightly Package") {
+            steps {
+                build(
+                    job: 'foreman-installer-develop-release',
+                    propagate: false,
+                    wait: false,
+                    parameters: [
+                        string(name: 'git_ref', value: commit_hash)
+                    ]
+                )
+            }
+        }
+    }
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}
+
+def run_test(args) {
+    def ruby = args.ruby
+    def puppet = args.puppet
+    def gemset = "ruby-${ruby}-puppet-${puppet}"
+
+    try {
+        configureRVM(ruby, gemset)
+        withRVM(["PUPPET_VERSION='${puppet}' bundle install --without=development --jobs=5 --retry=5"], ruby, gemset)
+        withRVM(["PUPPET_VERSION='${puppet}' bundle exec rake spec"], ruby, gemset)
+    } finally {
+        cleanupRVM(ruby, gemset)
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-selinux-develop-test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-selinux-develop-test.groovy
@@ -1,0 +1,48 @@
+def commit_hash = ''
+
+pipeline {
+    agent { label 'el' }
+
+    options {
+        timestamps()
+        timeout(time: 2, unit: 'HOURS')
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage("Collect Git Hash") {
+            steps {
+                git(url: 'https://github.com/theforeman/foreman-selinux', branch: 'develop')
+                script {
+                    commit_hash = archive_git_hash()
+                }
+            }
+        }
+        stage("Build for rhel7") {
+            steps {
+                script {
+                    distro = 'rhel7'
+                    instprefix = pwd(tmp: true)
+                }
+                sh "make INSTPREFIX=${instprefix}/${distro} DISTRO=${distro}"
+            }
+        }
+        stage("Release Nightly Package") {
+            steps {
+                build(
+                    job: 'foreman-selinux-develop-release',
+                    propagate: false,
+                    wait: false,
+                    parameters: [
+                        string(name: 'git_ref', value: commit_hash)
+                    ]
+                )
+            }
+        }
+    }
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-katello-master-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-katello-master-release.groovy
@@ -1,4 +1,4 @@
-def git_url = 'https://github.com/katello/hammer-cli-katello.git'
+def git_url = 'https://github.com/Katello/hammer-cli-katello.git'
 def git_ref = 'master'
 def obal_package_name = 'rubygem-hammer_cli_katello'
 def project_name = 'hammer-cli-katello'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-katello-master-test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-katello-master-test.groovy
@@ -1,0 +1,4 @@
+def git_url = 'https://github.com/Katello/hammer-cli-katello'
+def git_ref = 'master'
+def hammer_cli_git_repos = ['hammer-cli', 'hammer-cli-foreman', 'hammer-cli-foreman-tasks', 'hammer_cli_foreman_bootdisk', 'hammer_cli_foreman_docker']
+def release_job = 'hammer-cli-katello-master-release'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-installer-develop-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-installer-develop-release.yaml
@@ -10,9 +10,6 @@
       - string:
           name: git_ref
           description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
-    triggers:
-      - timed: 'H 3 * * 1-5'
-      - github
     publishers:
       - ircbot_freenode
     dsl:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-selinux-develop-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/foreman-selinux-develop-release.yaml
@@ -10,9 +10,6 @@
       - string:
           name: git_ref
           description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
-    triggers:
-      - timed: 'H 3 * * 1'
-      - github
     publishers:
       - ircbot_freenode
     dsl:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/hammer-cli-katello-master-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/hammer-cli-katello-master-release.yaml
@@ -11,8 +11,6 @@
           name: git_ref
           default: master
           description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
-    triggers:
-      - github
     dsl:
       !include-raw:
         - pipelines/vars/hammer-cli-katello-master-release.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/foreman-installer-develop-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/foreman-installer-develop-test.yaml
@@ -1,0 +1,17 @@
+- job:
+    name: foreman-installer-develop-test
+    project-type: pipeline
+    sandbox: true
+    quiet-period: 600
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-installer
+    concurrent: false
+    triggers:
+      - timed: 'H 3 * * 1-5'
+      - github
+    dsl:
+      !include-raw:
+        - pipelines/test/foreman-installer-develop-test.groovy
+        - pipelines/lib/rvm.groovy
+        - pipelines/lib/git.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/foreman-selinux-develop-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/foreman-selinux-develop-test.yaml
@@ -1,0 +1,16 @@
+- job:
+    name: foreman-selinux-develop-test
+    project-type: pipeline
+    sandbox: true
+    quiet-period: 600
+    properties:
+      - github:
+          url: https://github.com/theforeman/foreman-selinux
+    concurrent: false
+    triggers:
+      - github
+    dsl:
+      !include-raw:
+        - pipelines/test/foreman-selinux-develop-test.groovy
+        - pipelines/lib/rvm.groovy
+        - pipelines/lib/git.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/hammer-cli-katello-master-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/tests/hammer-cli-katello-master-test.yaml
@@ -1,0 +1,16 @@
+- job:
+    name: hammer-cli-katello-master-test
+    project-type: pipeline
+    sandbox: true
+    concurrent: false
+    properties:
+      - github:
+          url: 'https://github.com/Katello/hammer-cli-katello'
+    triggers:
+      - github
+    dsl:
+      !include-raw:
+        - pipelines/vars/hammer-cli-katello-master-test.groovy
+        - pipelines/test/hammer-cli-x-test.groovy
+        - pipelines/lib/rvm.groovy
+        - pipelines/lib/git.groovy


### PR DESCRIPTION
Individual commits have relevant commit messages:

d741fbd6 (Ewoud Kohl van Wijngaarden, 3 minutes ago)
   Introduce a hammer-cli-katello-master-test job

   This runs the tests before releasing.

d6b1d286 (Ewoud Kohl van Wijngaarden, 20 minutes ago)
   Introduce a foreman-selinux-develop-test job

   This follows the pattern of having a -test job to verify functionality and a -release job to build packages.

   It avoids the rebuild for every foreman-packaging change issue.

   This change drops the timed builds which aren't needed for foreman-selinux since it doesn't bundle anything.

673b7205 (Ewoud Kohl van Wijngaarden, 35 minutes ago)
   Add a foreman-installer-develop-test job

   This works towards the pattern of having a -test job to run tests and then a -release job to actually release it.

   An additional benefit is that we will stop building an installer for every merged PR to foreman-packaging.

   It is not complete since the tests with the actual modules, as we do in Travis, are not ran. Those wouldn't be correct because there is a timing issue. The -test job runs, then the -release job builds a tarbal from potentially different sources.

0b22c711 (Ewoud Kohl van Wijngaarden, 15 minutes ago)
   Do not use isAllWhitespace

   This method is not allowed in a sandbox and breaks our release pipelines.