### PR TITLE
Ensure selinux-policy-devel is installed

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -222,6 +222,11 @@ class slave (
     }
   }
 
+  # Needed for foreman-selinux testing
+  if $::osfamily == 'RedHat' {
+    ensure_packages(['selinux-policy-devel'])
+  }
+
   # needed by katello gem dependency qpid-messaging
   # to interface with candlepin's event topic
   if $::osfamily == 'RedHat' {


### PR DESCRIPTION
5c1ba8ac124b120492c4d91ba2455f6da195ac90 introduced a foreman-selinux test job, but this requires selinux-policy-devel to be installed.