### PR TITLE
Move to a source and package release model

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
@@ -1,5 +1,7 @@
 def commit_hash = ''
 foreman_branch = 'develop'
+project_name = 'foreman'
+source_type = 'rake'
 
 pipeline {
     agent { label 'fast' }
@@ -198,10 +200,20 @@ pipeline {
                 }
             }
         }
+        stage('Build and Archive Source') {
+            steps {
+                dir(project_name) {
+                    git url: 'https://github.com/theforeman/foreman', branch: foreman_branch
+                }
+                script {
+                    sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
+                }
+            }
+        }
         stage('packaging') {
             steps {
                 build(
-                    job: 'foreman-develop-release',
+                    job: 'foreman-develop-package-release',
                     propagate: false,
                     wait: false,
                     parameters: [

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-develop-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-develop-package-release.yaml
@@ -1,5 +1,5 @@
 - job:
-    name: foreman-develop-release
+    name: foreman-develop-package-release
     project-type: pipeline
     sandbox: true
     concurrent: false

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-develop-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-develop-source-release.yaml
@@ -1,5 +1,5 @@
 - job:
-    name: foreman-develop-test
+    name: foreman-develop-source-release
     project-type: pipeline
     sandbox: true
     quiet-period: 2700
@@ -10,7 +10,9 @@
       - github
     dsl:
       !include-raw:
-        - pipelines/test/test_foreman.groovy
+        - pipelines/release/source/foreman.groovy
+        - pipelines/lib/nightly_packaging.groovy
+        - pipelines/lib/foreman_infra.groovy
         - pipelines/lib/rvm.groovy
         - pipelines/lib/git.groovy
         - pipelines/lib/foreman.groovy


### PR DESCRIPTION
This changes the idea of a 'test' job that is run on PR merge to
a source release job. The source release job aims to test the code
and then create a source release if that tested code is green.

The previous release job is renamed to be a package-release job to
better specify that its focused only on releasing a package.

The overall idea is to split source generation and release from
package creation given that source can be an input to multiple places.