### PR TITLE
Always install node modules for plugin prs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/builders/foreman-plugins-pull-request.yaml
@@ -32,11 +32,6 @@
 
           bundle install --without development --jobs=5 --retry=5
 
-          # we need to install node modules for integration tests
-          if [ -e "${{APP_ROOT}}/package.json" ]; then
-            npm install
-          fi
-
           # Database environment
           (
             sed "s/^test:/development:/; s/database:.*/database: test-${{gemset}}-dev/" ${{HOME}}/${{database}}.db.yaml
@@ -59,10 +54,8 @@
           # Update dependencies
           bundle update --jobs=5 --retry=5
 
-          # If the plugin contains npm deps, we need to install its specific modules
-          if [ -e "${{PLUGIN_ROOT}}/package.json" ]; then
-            npm install
-          fi
+          # we need to install node modules for integration tests
+          npm install
 
           # Now let's add the plugin migrations
           bundle exec rake db:migrate


### PR DESCRIPTION
Salt depends on foreman-tasks which needs npm install to properly
compile webpack, but because salt doesn't have a package.json npm
install is run too early, when only foreman core is set up.