### PR TITLE
Update Debian building to new job names

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_deb.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_deb.sh
@@ -30,7 +30,7 @@ repo=${pr_git_short_ref}
 version=${branch_version}
 EOF
 
-  [ $p = foreman ] && echo "nightly_jenkins_job=foreman-develop-release" >> test_builds/debian/${p}.properties || true
+  [ $p = foreman ] && echo "nightly_jenkins_job=foreman-develop-source-release" >> test_builds/debian/${p}.properties || true
   [ $p = foreman-proxy ] && echo "nightly_jenkins_job=smart-proxy-develop-release" >> test_builds/debian/${p}.properties || true
   [ $p = foreman-selinux ] && echo "nightly_jenkins_job=foreman-selinux-develop-release" >> test_builds/debian/${p}.properties || true
   [ $p = foreman-installer ] && echo "nightly_jenkins_job=foreman-installer-develop-release" >> test_builds/debian/${p}.properties || true

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -75,7 +75,8 @@ Any value other than "theforeman" will be pushed to http://stagingdeb.theforeman
       - choice:
           name: nightly_jenkins_job
           choices:
-            - foreman-develop-release
+            - foreman-develop-source-release
+            - foreman-develop-package-release
             - smart-proxy-develop-release
             - foreman-installer-develop-release
           description: 'When building nightly (develop), name of the Jenkins job that contains the source file(s) (tarballs, gems) to build, e.g. test_develop'


### PR DESCRIPTION
ee7f1c6269609e612b50b7acb90e9b1e170d7b61 moved the foreman jobs around. This allows the Debian package building to use those new jobs.