### PR TITLE
Shorten the database names

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
@@ -49,7 +49,7 @@ test:
 
 development:
   adapter: postgresql
-  database: test-${id}-development
+  database: test-${id}-dev
   username: foreman
   password: foreman
   host: localhost
@@ -57,7 +57,7 @@ development:
 
 production:
   adapter: postgresql
-  database: test-${id}-production
+  database: test-${id}-prod
   username: foreman
   password: foreman
   host: localhost
@@ -76,14 +76,14 @@ test:
 
 development:
   adapter: mysql2
-  database: test-${id}-development
+  database: test-${id}-dev
   username: foreman
   password: foreman
   host: localhost
 
 production:
   adapter: mysql2
-  database: test-${id}-production
+  database: test-${id}-prod
   username: foreman
   password: foreman
   host: localhost


### PR DESCRIPTION
The source release job is failing because the database name is too long. test-foreman-develop-source-release-11-ruby-2-5-mysql-development is 65 characters while the limit is 64.