### PR TITLE
disable concurrent builds for foreman-packaging-release

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman_packaging_release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman_packaging_release.groovy
@@ -6,6 +6,7 @@ pipeline {
     options {
         timestamps()
         timeout(time: 2, unit: 'HOURS')
+        disableConcurrentBuilds()
         ansiColor('xterm')
     }
 


### PR DESCRIPTION
not only set concurrent:false but also add disableConcurrentBuilds to
the pipeline definition

the way we currently track "hat has been built" does not allow for
concurrent building