### PR TITLE
Adjust Debian jobs to the new package naming conventions

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_deb.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_deb.sh
@@ -30,10 +30,11 @@ repo=${pr_git_short_ref}
 version=${branch_version}
 EOF
 
-  [ $p = foreman ] && echo "nightly_jenkins_job=foreman-develop-source-release" >> test_builds/debian/${p}.properties || true
-  [ $p = foreman-proxy ] && echo "nightly_jenkins_job=smart-proxy-develop-release" >> test_builds/debian/${p}.properties || true
-  [ $p = foreman-selinux ] && echo "nightly_jenkins_job=foreman-selinux-develop-release" >> test_builds/debian/${p}.properties || true
-  [ $p = foreman-installer ] && echo "nightly_jenkins_job=foreman-installer-develop-release" >> test_builds/debian/${p}.properties || true
+  if [[ $p == foreman-proxy ]] ; then
+    echo "nightly_jenkins_job=smart-proxy-develop-source-release" >> test_builds/debian/${p}.properties
+  elif [[ $p == foreman* ]] ; then
+    echo "nightly_jenkins_job=$p-develop-source-release" >> test_builds/debian/${p}.properties
+  fi
 done
 
 # identify changed dependencies, 5 at most!

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -76,9 +76,8 @@ Any value other than "theforeman" will be pushed to http://stagingdeb.theforeman
           name: nightly_jenkins_job
           choices:
             - foreman-develop-source-release
-            - foreman-develop-package-release
-            - smart-proxy-develop-release
-            - foreman-installer-develop-release
+            - foreman-installer-develop-source-release
+            - smart-proxy-develop-source-release
           description: 'When building nightly (develop), name of the Jenkins job that contains the source file(s) (tarballs, gems) to build, e.g. test_develop'
       - string:
           name: nightly_jenkins_job_id


### PR DESCRIPTION
37b6224fbc1ca5cea9e92eb3fdec8dbc06727e0e renamed the jobs but omitted the change to Debian jobs.