### PR TITLE
Do not include rsync in utility

### DIFF
--- a/puppet/modules/utility/manifests/init.pp
+++ b/puppet/modules/utility/manifests/init.pp
@@ -8,7 +8,9 @@ class utility($sysadmins = ['/dev/null']) {
     default  => 'vim',
   }
 
-  ensure_packages([$vim, 'htop', 'iftop', 'screen', 'rsync', 'ruby-shadow'])
+  ensure_packages([$vim, 'htop', 'iftop', 'screen', 'ruby-shadow'])
+
+  # TODO: rsync package is managed by puppetlabs-rsync
 
   mailalias { 'sysadmins':
     ensure    => present,


### PR DESCRIPTION
It's included in the rsync module which leads to duplicate resources. It may be possible to include the rsync class here, but that might result in other duplicate resources.

e58d934e00f51531880ce534ae344edbf3cd9e60 introduced this change so it's safest to revert it for now.