### PR TITLE
Allow -package-release jobs as sources

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -76,8 +76,11 @@ Any value other than "theforeman" will be pushed to http://stagingdeb.theforeman
           name: nightly_jenkins_job
           choices:
             - foreman-develop-source-release
+            - foreman-develop-package-release
             - foreman-installer-develop-source-release
+            - foreman-installer-develop-package-release
             - smart-proxy-develop-source-release
+            - smart-proxy-develop-package-release
           description: 'When building nightly (develop), name of the Jenkins job that contains the source file(s) (tarballs, gems) to build, e.g. test_develop'
       - string:
           name: nightly_jenkins_job_id


### PR DESCRIPTION
Currently these jobs still build tarballs and are package sources so they should be allowed.