### PR TITLE
Handle HTTPS in unmanaged_jobs.rb

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/unmanaged_jobs.rb
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/unmanaged_jobs.rb
@@ -13,7 +13,7 @@ def managed?(job)
 end
 
 def get_jenkins_url_from_ini(ini_file)
-  regex = /url\s?=(.*\/\/)?/
+  regex = /url\s*=\s*/
 
   lines = File.open(ini_file, "r") do |file|
     file.readlines
@@ -44,7 +44,8 @@ def main
   url = get_jenkins_url_from_ini(inifile)
   fail "url is blank" unless url
 
-  payload = Net::HTTP.get(url, '/api/json?tree=jobs[name,description]')
+  uri = URI("#{url}/api/json?tree=jobs[name,description]")
+  payload = Net::HTTP.get(uri)
 
   unmanaged_jobs = find_unmanaged_jobs_from_payload(payload)
 


### PR DESCRIPTION
Previously it stripped the scheme. That meant it fell back to HTTP which does a redirect to HTTPS. This raised an error instead of the intended operation. By including the scheme, net/http can perform the correct request.