### PR TITLE
Deploy yum content to web02

### DIFF
--- a/deploy/config/deploy/yum.rb
+++ b/deploy/config/deploy/yum.rb
@@ -2,7 +2,7 @@ set :application, "yum.theforeman.org"
 set :user_sudo, false
 
 # parameters, use cap -S
-set :host, fetch(:host, "yum.theforeman.org")
+set :host, fetch(:host, "web02.theforeman.org")
 #set :repo_source, "foreman-nightly/RHEL/6"
 #set :repo_dest, "nightly/el6"
 set :overwrite, fetch(:overwrite, false)


### PR DESCRIPTION
Now that yum.theforeman.org is behind a CDN, we need to push to the actual host which is currently web02.