### PR TITLE
Copy sources in foreman-x-develop-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ We're starting to implement some some job naming conventions.
 
 **Note** Because `centos.org` is a shared environment all jobs are prefixed by `foreman-` to denote they're ours.
 
-| **Name**                | **Convention**                        | **Example 1**            | **Example 2**                     |
-|-------------------------|---------------------------------------|--------------------------|-----------------------------------|
-| Nightly Package Builder | {git-repo}-{git-branch}-release       | foreman-develop-release  | hammer-cli-katello-master-release |
-| CI pipeline             | {repository}-{environment}-pipeline   | foreman-nightly-pipeline | plugins-nightly-pipeline          |
-| Pull Request testing    | {git-repo}-{optional-concern}-pr-test | katello-pr-test          | foreman-packaging-rpm-pr-test     |
+| **Name**                | **Convention**                                         | **Example 1**                   | **Example 2**                             |
+|-------------------------|--------------------------------------------------------|---------------------------------|-------------------------------------------|
+| Nightly Source Builder  | {git-repo}-{git-branch}-source-release                 | foreman-develop-source-release  | hammer-cli-katello-master-source-release  |
+| Nightly Package Builder | {git-repo}-{git-branch}-package-release                | foreman-develop-package-release | hammer-cli-katello-master-package-release |
+| CI pipeline             | {repository}-{environment}-{optional-concern}-pipeline | foreman-nightly-rpm-pipeline    | foreman-nightly-deb-pipeline              |
+| Pull Request testing    | test_{git-repo}_{optional-concern}_pull_request        | katello-pr-test                 | foreman-packaging-rpm-pr-test             |

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-installer.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-installer.groovy
@@ -51,10 +51,7 @@ pipeline {
                 build(
                     job: "${project_name}-${foreman_branch}-package-release",
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-selinux.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-selinux.groovy
@@ -45,10 +45,7 @@ pipeline {
                 build(
                     job: "${project_name}-${foreman_branch}-package-release",
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
@@ -160,10 +160,7 @@ pipeline {
                 build(
                     job: "${project_name}-${foreman_branch}-package-release",
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
@@ -44,10 +44,7 @@ pipeline {
                 build(
                     job: "${project_name}-${foreman_branch}-package-release",
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -139,10 +139,7 @@ pipeline {
                 build(
                     job: "${project_name}-${foreman_branch}-package-release",
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -46,10 +46,7 @@ pipeline {
                 build(
                     job: "${project_name}-${foreman_branch}-package-release",
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-selinux-develop-test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-selinux-develop-test.groovy
@@ -32,10 +32,7 @@ pipeline {
                 build(
                     job: 'foreman-selinux-develop-release',
                     propagate: false,
-                    wait: false,
-                    parameters: [
-                        string(name: 'git_ref', value: commit_hash)
-                    ]
+                    wait: false
                 )
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-develop-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-develop-package-release.yaml
@@ -8,11 +8,6 @@
           url: 'https://github.com/theforeman/foreman'
     publishers:
       - ircbot_freenode
-    parameters:
-      - string:
-          name: git_ref
-          default: develop
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     dsl:
       !include-raw:
         - pipelines/vars/foreman-develop-release.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-installer-develop-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-installer-develop-package-release.yaml
@@ -6,10 +6,6 @@
     properties:
       - github:
           url: 'https://github.com/theforeman/foreman-installer'
-    parameters:
-      - string:
-          name: git_ref
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     publishers:
       - ircbot_freenode
     dsl:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-selinux-develop-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/foreman-selinux-develop-package-release.yaml
@@ -6,10 +6,6 @@
     properties:
       - github:
           url: 'https://github.com/theforeman/foreman-selinux'
-    parameters:
-      - string:
-          name: git_ref
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     publishers:
       - ircbot_freenode
     dsl:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/hammer-cli-foreman-master-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/hammer-cli-foreman-master-package-release.yaml
@@ -6,11 +6,6 @@
     properties:
       - github:
           url: 'https://github.com/theforeman/hammer-cli-foreman'
-    parameters:
-      - string:
-          name: git_ref
-          default: master
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     dsl:
       !include-raw:
         - pipelines/vars/hammer-cli-foreman-master.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/hammer-cli-katello-master-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/hammer-cli-katello-master-package-release.yaml
@@ -6,11 +6,6 @@
     properties:
       - github:
           url: 'https://github.com/katello/hammer-cli-katello'
-    parameters:
-      - string:
-          name: git_ref
-          default: master
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     dsl:
       !include-raw:
         - pipelines/vars/hammer-cli-katello-master.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/hammer-cli-master-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/hammer-cli-master-package-release.yaml
@@ -8,11 +8,6 @@
           url: 'https://github.com/theforeman/hammer-cli'
     publishers:
       - ircbot_freenode
-    parameters:
-      - string:
-          name: git_ref
-          default: master
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     dsl:
       !include-raw:
         - pipelines/vars/hammer-cli-master.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/katello-master-package-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/katello-master-package-release.yaml
@@ -8,11 +8,6 @@
     properties:
       - github:
           url: 'https://github.com/katello/katello'
-    parameters:
-      - string:
-          name: git_ref
-          default: master
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     dsl:
       !include-raw:
         - pipelines/vars/katello-master-release.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/smart-proxy-develop-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/package/smart-proxy-develop-source-release.yaml
@@ -6,10 +6,6 @@
     properties:
       - github:
           url: 'https://github.com/theforeman/smart-proxy'
-    parameters:
-      - string:
-          name: git_ref
-          description: Branch name, tag, or git hash. Defaults to project's development branch if left blank.
     dsl:
       !include-raw:
         - pipelines/vars/smart-proxy-develop-release.groovy


### PR DESCRIPTION
Since all jobs now follow $project-$branch-source-release, we can rely on those to generate the tarball.

Also cleans up an unused publisher and updates the conventions in README.md.