### PR TITLE
don't set logging path to / but to an empty string

### DIFF
--- a/ansible/fastly.yml
+++ b/ansible/fastly.yml
@@ -40,7 +40,7 @@
             format_version: '2'
             gzip_level: '0'
             message_type: classic
-            path: "/"
+            path: ""
             period: '3600'
             placement:
             public_key:
@@ -54,7 +54,7 @@
             format_version: '2'
             gzip_level: '0'
             message_type: classic
-            path: "/"
+            path: ""
             period: '3600'
             placement:
             public_key:


### PR DESCRIPTION
setting it to / makes the logfiles start with a / which confuses some clients