### PR TITLE
Trigger katello-master-package-release with correct parameter

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -1,4 +1,3 @@
-def commit_hash = ''
 foreman_branch = 'master'
 project_name = 'katello'
 source_type = 'gem'
@@ -139,7 +138,7 @@ pipeline {
                     propagate: false,
                     wait: false,
                     parameters: [
-                        string(name: 'git_ref', value: commit_hash)
+                        string(name: 'git_ref', value: foreman_branch)
                     ]
                 )
             }


### PR DESCRIPTION
Otherwise, k-m-source-release triggers it with an empty gitref causing
the job to fail