### PR TITLE
Refactor plugins pipeline

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rpm_packaging.groovy
@@ -50,3 +50,29 @@ def repoclosure(repo, dist, version) {
         )
     }
 }
+
+def repoclosures(repo, versions) {
+    def results = [:]
+
+    // Run all repoclosure steps sequentially and store the result because
+    // yum on EL7 aggressively shares caches which breaks concurrent
+    // repoclosures
+    versions.each { version, distros ->
+        distros.each { distro, os ->
+            script {
+                stage("repoclosure-${version}-${distro}") {
+                    script {
+                        try {
+                            repoclosure('plugins', distro, version)
+                            results["${version}-${distro}"] = true
+                        } catch(Exception ex) {
+                            results["${version}-${distro}"] = ex
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return results
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanPluginsRelease.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foremanPluginsRelease.groovy
@@ -1,4 +1,9 @@
-def versions = [:]
+def versions = [
+    "nightly": ["el7": "RHEL/7"],
+    "1.22": ["el7": "RHEL/7"],
+    "1.21": ["el7": "RHEL/7"],
+    "1.20": ["el7": "RHEL/7"]
+]
 
 pipeline {
     agent { label 'admin && sshkey' }
@@ -18,111 +23,37 @@ pipeline {
 
             }
         }
-        stage('Setup Push Environment') {
-            steps {
-
-                git_clone_foreman_infra()
-                dir('deploy') { withRVM(["bundle install --jobs=5 --retry=5"]) }
-
-            }
-        }
-        stage('repoclosure-nightly-el7') {
+        stage('Repoclosures') {
             steps {
                 script {
-                    try {
-                        repoclosure('plugins', 'el7', 'nightly')
-                        versions['nightly'] = true
-                    } catch(Exception ex) {
-                        versions['nightly'] = false
-                    }
-                }
-            }
-        }
-        stage('repoclosure-1.22-el7') {
-            steps {
-                script {
-                    try {
-                        repoclosure('plugins', 'el7', '1.22')
-                        versions['1.22'] = true
-                    } catch(Exception ex) {
-                        versions['1.22'] = false
-                    }
-                }
-            }
-        }
-        stage('repoclosure-1.21-el7') {
-            steps {
-                script {
-                    try {
-                        repoclosure('plugins', 'el7', '1.21')
-                        versions['1.21'] = true
-                    } catch(Exception ex) {
-                        versions['1.21'] = false
-                    }
-                }
-            }
-        }
-        stage('repoclosure-1.20-el7') {
-            steps {
-                script {
-                    try {
-                        repoclosure('plugins', 'el7', '1.20')
-                        versions['1.20'] = true
-                    } catch(Exception ex) {
-                        versions['1.20'] = false
-                    }
+                    results = repoclosures('plugins', versions)
                 }
             }
         }
         stage('push-rpms') {
-            parallel {
-                stage('push-nightly-el7') {
-                    steps {
-                        script {
-                            if (versions['nightly']) {
-                                push_rpms('nightly', 'el7')
-                            } else {
-                                sh "echo nightly el7 repoclosure failed"
-                                sh "exit 1"
-                            }
-                        }
-                    }
+            steps {
+                git_clone_foreman_infra()
+                dir('deploy') {
+                    withRVM(["bundle install --jobs=5 --retry=5"])
                 }
-                stage('push-1.22-el7') {
-                    steps {
-                        script {
-                            if (versions['1.22']) {
-                                push_rpms('1.22', 'el7')
-                            } else {
-                                sh "echo 1.22 el7 repoclosure failed"
-                                sh "exit 1"
+                script {
+                    def pushVersions = [:]
+                    versions.each { version, distros ->
+                        distros.each { distro, os ->
+                            pushVersions["push-${version}-${distro}"] = {
+                                script {
+                                    if (results["${version}-${distro}"] == true) {
+                                        push_rpms_direct("foreman-plugins-${version}/${os}", "plugins/${version}/${distro}", false, true)
+                                    } else {
+                                        echo "${version} ${distro} repoclosure failed: ${results[version]}"
+                                        throw results["${version}-${distro}"]
+                                    }
+                                }
                             }
                         }
                     }
-                }
-                stage('push-1.21-el7') {
-                    steps {
-                        script {
-                            if (versions['1.21']) {
-                                push_rpms('1.21', 'el7')
-                            } else {
-                                sh "echo 1.21 el7 repoclosure failed"
-                                sh "exit 1"
-                            }
-                        }
-                    }
-                }
-                stage('push-1.20-el7') {
-                    steps {
-                        script {
-                            if (versions['1.20']) {
-                                push_rpms('1.20', 'el7')
-                            } else {
-                                sh "echo 1.20 el7 repoclosure failed"
-                                sh "exit 1"
-                            }
-                        }
-                    }
+
+                    parallel pushVersions
                 }
             }
         }
@@ -132,19 +63,4 @@ pipeline {
             deleteDir()
         }
     }
-}
-
-void push_rpms(version, distro) {
-    def os = 'RHEL/7'
-
-    dir('deploy') {
-
-        if (distro == 'f24') {
-            os = 'Fedora/24'
-        }
-
-        push_rpms_direct("foreman-plugins-${version}/${os}", "plugins/${version}/${distro}", false, true)
-
-    }
-
 }


### PR DESCRIPTION
This refactors the pipeline to be driven by configuration and allows changing the versions by just changing the versions hash at the top. The end result is still readable for end users in the same way. It may be even more readable by printing the exception.

It also allows defining multiple distributions which will be useful when we add EL8 support.