### PR TITLE
Increase CentOS CI polling timeout

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
@@ -90,7 +90,7 @@
       register: build_job_result
       until: (build_job_result.json is defined) and (build_job_result.json.result == 'SUCCESS' or build_job_result.json.result == 'FAILURE')
       retries: 360
-      delay: 20
+      delay: 30
 
     - fail:
         msg: "Build Job Failed"


### PR DESCRIPTION
Otherwise, builds that take longer than two hours time out.
Instead of increasing the count I increased the delay between polls - 30
seconds is often enough, 10 seconds extra delay to get the results isn't
too bad and in the case of shorter jobs will reduce the amount of
requests needed.