### PR TITLE
Remove kubevirt hammer job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -94,7 +94,5 @@
           repo: 'https://github.com/theforeman/puppetdb_foreman'
       - foreman_kubevirt:
           repo: 'https://github.com/theforeman/foreman_kubevirt.git'
-      - hammer-cli-foreman-kubevirt:
-          repo: 'https://github.com/theforeman/hammer-cli-foreman-kubevirt.git'
     jobs:
       - '{plugin}-pull-request'


### PR DESCRIPTION
This job is tested as it were a foreman plugin. That doesn't work.