### PR TITLE
Allow using puppet-5 in repoclosure

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_repoclosure.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/packaging_repoclosure.sh
@@ -45,7 +45,7 @@ if [ -n "${copr_lookasides}" ]; then
 fi
 
 predefined_lookaside=""
-predefined_lookasides="${predefined_lookasides} base updates extras epel scl puppet-6"
+predefined_lookasides="${predefined_lookasides} base updates extras epel scl puppet-6 puppet-5"
 if [[ -n $predefined_lookasides ]]; then
   lookaside_repos=$(echo $predefined_lookasides | tr "," "\n")
 


### PR DESCRIPTION
232dc5f56b5b73a391a844988fe822a48d7784c6 updated to Puppet 6 but Foreman 1.20 and 1.21 are incompatible and need to use puppet 5. Since we only have one in the repoclosure config we'll only enable the one that's actually present.