### PR TITLE
Remove Puppet from the Smart Proxy testing matrix

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -21,44 +21,24 @@ pipeline {
                 }
             }
         }
-        stage("test ruby-2.0.0 & puppet-3.8.0") {
+        stage("test ruby-2.0") {
             steps {
-                run_test(ruby: '2.0.0', puppet: '3.8.0')
+                run_test(ruby: '2.0.0')
             }
         }
-        stage("test ruby-2.1 & puppet-3.8.0") {
+        stage("test ruby-2.3") {
             steps {
-                run_test(ruby: '2.1', puppet: '3.8.0')
+                run_test(ruby: '2.3')
             }
         }
-        stage("test ruby-2.1 & puppet-4.10.9") {
+        stage("test ruby-2.5") {
             steps {
-                run_test(ruby: '2.1', puppet: '4.10.9')
+                run_test(ruby: '2.5')
             }
         }
-        stage("test ruby-2.3 & puppet-4.10.9") {
+        stage("test ruby-2.6") {
             steps {
-                run_test(ruby: '2.3', puppet: '4.10.9')
-            }
-        }
-        stage("test ruby-2.4 & puppet-4.10.9") {
-            steps {
-                run_test(ruby: '2.4', puppet: '4.10.9')
-            }
-        }
-        stage("test ruby-2.4 & puppet-5.3.3") {
-            steps {
-                run_test(ruby: '2.4', puppet: '5.3.3')
-            }
-        }
-        stage("test ruby-2.5 & puppet-4.10.9") {
-            steps {
-                run_test(ruby: '2.5', puppet: '4.10.9')
-            }
-        }
-        stage("test ruby-2.5 & puppet-5.3.3") {
-            steps {
-                run_test(ruby: '2.5', puppet: '5.3.3')
+                run_test(ruby: '2.6')
             }
         }
         stage('Build and Archive Source') {
@@ -96,14 +76,13 @@ pipeline {
 
 def run_test(args) {
     def ruby = args.ruby
-    def puppet = args.puppet
-    def gemset = "ruby-${ruby}-puppet-${puppet}"
+    def gemset = "ruby-${ruby}"
 
     try {
         configureRVM(ruby, gemset)
         withRVM(["cp config/settings.yml.example config/settings.yml"], ruby, gemset)
-        withRVM(["PUPPET_VERSION='${puppet}' bundle install --without=development --jobs=5 --retry=5"], ruby, gemset)
-        withRVM(["PUPPET_VERSION='${puppet}' bundle exec rake jenkins:unit --trace"], ruby, gemset)
+        withRVM(["bundle install --without=development --jobs=5 --retry=5"], ruby, gemset)
+        withRVM(["bundle exec rake jenkins:unit --trace"], ruby, gemset)
     } finally {
         cleanupRVM(ruby, gemset)
         junit(testResults: 'jenkins/reports/unit/*.xml')

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_proxy_develop_pr_core.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_proxy_develop_pr_core.sh
@@ -19,10 +19,5 @@ set -x
 #gem update --no-document
 gem install bundler -v '< 2.0' --no-document
 
-# Puppet environment
-if [ -e $APP_ROOT/bundler.d/puppet.rb ] ; then
-	sed -i "/^\s*gem.*puppet/ s/\$/, '~> $puppet'/" $APP_ROOT/bundler.d/puppet.rb
-fi
-
 bundle install --without=development --jobs=5 --retry=5
-bundle exec rake pkg:generate_source jenkins:unit
+bundle exec rake jenkins:unit

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_proxy_develop_pr_core.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_proxy_develop_pr_core.yaml
@@ -1,7 +1,7 @@
 - job:
     name: test_proxy_develop_pr_core
     description: |
-      Tests a Smart Proxy pull request under each Ruby and Puppet configuration.
+      Tests a Smart Proxy pull request under each Ruby.
     project-type: matrix
     concurrent: true
     properties:
@@ -27,15 +27,7 @@
             - '2.0.0'
             - '2.3'
             - '2.5'
-      - axis:
-          type: user-defined
-          name: puppet
-          values:
-            - '3.8.0'
-            - '4.10.0'
-            - '5.0'
-    execution-strategy:
-      combination-filter: '( ruby == "2.0.0" && puppet ==~ /[34]\..*/ ) || ( ruby == "2.3" && puppet == "4.10.0" ) || ( ruby ==~ /2\.[45].*/ && puppet == "5.0" )'
+            - '2.6'
     wrappers:
       - timeout:
           type: absolute


### PR DESCRIPTION
Now that the Puppet gem is never included anymore, it's no longer needed to test this. Also adds Ruby 2.6 to the matrix.