### PR TITLE
Compile webpack when running integration tests

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/test_plugin.sh
@@ -55,14 +55,15 @@ echo "gem '${plugin_name}', :path => '${PLUGIN_ROOT}'" >> bundler.d/Gemfile.loca
 # Update dependencies
 bundle update --jobs=5 --retry=5
 
-# If the plugin contains npm deps, we need to install its specific modules
-# we need to install node modules for integration tests
-if [ -e "$APP_ROOT/package.json" ]; then
-  npm install
-fi
-
 # Now let's add the plugin migrations
 bundle exec rake db:migrate RAILS_ENV=development --trace
+
+# If the plugin contains integration tests or triggers core integration tests,
+# we need to install node modules and compile webpack
+if [ -d "${PLUGIN_ROOT}/test/integration" ] || [ ${database} = postgresql ]; then
+  npm install
+  bundle exec rake webpack:compile
+fi
 
 tasks="jenkins:unit"
 [ ${database} = postgresql ] && tasks="$tasks jenkins:integration"


### PR DESCRIPTION
Plugins currently enhance jenkins:unit task with all of their tests
including integration tests if present. This causes failures since we no
longer compile webpack by default when running tests. As a side effect,
plugins that do not include integration tests will no longer install
node modules as the previous condition was incorrect - it tested for the
presence of package.json in APP_ROOT (which is foreman core) instead of
PLUGIN_ROOT (which is the plugin's folder).