### PR TITLE
Use the correct luna server name

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/luna/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/luna/nightly.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-luna-nightly-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'centos7', 'pipeline_type': 'luna']]
+    playBook = ['boxes': ['pipeline-luna-server-nightly-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'centos7', 'pipeline_type': 'luna']]
     return playBook
 }


### PR DESCRIPTION
This is parallel to ec5f182ae9221280bc3983faae5701db78993200 but for luna instead of katello.