### PR TITLE
Stop using eslint for katello test

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -96,7 +96,6 @@ pipeline {
                     }
                     steps {
                         sh "npm install"
-                        sh 'npm run lint'
                         sh 'npm test'
                     }
                 }


### PR DESCRIPTION
The latest version of `eslint` and most of its plugins dropped the support for node-6/
It will be risky to continue running eslint on node-6.

Instead, I would like to run `eslint` using `.travis` wich is more straight forward to configure in this case.