### PR TITLE
Adds timed cron to katello dev job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/pipeline/katello-devel-forklift-test.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/pipeline/katello-devel-forklift-test.yaml
@@ -4,6 +4,7 @@
     project-type: pipeline
     sandbox: true
     triggers:
+      - timed: "H 12 * * *"
       - reverse:
           jobs:
             - katello-nightly-rpm-pipeline


### PR DESCRIPTION
The katello dev box job can be out of date and not accurately reflect whether the dev
box will spin up successfully. This commit adds a timed trigger to run the job twice
a day.