### PR TITLE
make mv less smart

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-discovery-image.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-discovery-image.groovy
@@ -32,7 +32,8 @@ pipeline {
             steps {
                 dir('result') {
                     sh """
-                    mv ../artifacts/fdi*tar ../artifacts/fdi*iso .
+                    mv ../artifacts/fdi*tar .
+                    mv ../artifacts/fdi*iso .
                     ln -snf fdi*tar fdi-image-latest.tar
                     md5sum fdi*tar fdi*iso > MD5SUMS
                     """


### PR DESCRIPTION
this avoids Jenkins quoting the input and the wildcards not matching