### PR TITLE
wait for the ci.centos.org job to fully finish

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
@@ -99,7 +99,7 @@
         password: "{{ jenkins_password }}"
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/api/json"
       register: build_job_result
-      until: (build_job_result.json is defined) and (build_job_result.json.result == 'SUCCESS' or build_job_result.json.result == 'FAILURE')
+      until: (build_job_result.json is defined) and (not build_job_result.json.building) and (build_job_result.json.result == 'SUCCESS' or build_job_result.json.result == 'FAILURE')
       retries: 360
       delay: 30
 


### PR DESCRIPTION
"result" is populated as soon as all stages finished, but we also want
the post actions to finish, as those may do some post-processing we
depend on (e.g. archiving artifacts)

the "building" entry is a boolean, declaring the overall job state