### PR TITLE
push to web02.tfm, not deb.tfm

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
@@ -21,7 +21,7 @@ void push_rpms_katello(version) {
 
 void push_debs_direct(os, repo) {
     sshagent(['freight']) {
-        sh "ssh freight@deb.theforeman.org deploy ${os} ${repo}"
+        sh "ssh freight@web02.theforeman.org deploy ${os} ${repo}"
     }
 }
 


### PR DESCRIPTION
we want to move deb.tfm to the cdn at some point