### PR TITLE
ignore delete errors in freight receive script

### DIFF
--- a/puppet/modules/freight/templates/rsync.erb
+++ b/puppet/modules/freight/templates/rsync.erb
@@ -11,4 +11,4 @@
   # Publish the debs
   freight-cache -c <%= @home %>/freight.conf -v apt/$DISTRO
   # Cleanup - no need to keep the debs
-  find <%= @home %>/rsync_cache/$DISTRO/$REPO -iname '*.deb' -delete
+  find <%= @home %>/rsync_cache/$DISTRO/$REPO -iname '*.deb' -delete || true

--- a/puppet/modules/freight/templates/rsync_main.erb
+++ b/puppet/modules/freight/templates/rsync_main.erb
@@ -40,7 +40,7 @@ if [[ `echo "${SSH_ORIGINAL_COMMAND}" | awk '{ print $NF }'` =~ ^rsync_cache/.* 
   # Publish the debs
   freight-cache -c <%= @home %>/freight.conf -v apt/$DISTRO
   # Cleanup - no need to keep the debs
-  find <%= @home %>/rsync_cache/$DISTRO/$REPO -iname '*.deb' -delete
+  find <%= @home %>/rsync_cache/$DISTRO/$REPO -iname '*.deb' -delete || true
 fi
 ;;
 deploy*)


### PR DESCRIPTION
if we run multiple publishes in parallel, it might be that one already
finished the cleanup, so the other would error out trying to delete the
files. let's just ignore errors from the find -delete call.