### PR TITLE
always archive Gemfile.lock after installing Foreman dependencies

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman.groovy
@@ -17,6 +17,7 @@ def addSettings(settings) {
 
 def configureDatabase(ruby, name = '') {
     withRVM(['bundle install --without=development --jobs=5 --retry=5'], ruby, name)
+    archiveArtifacts(artifacts: 'Gemfile.lock')
     withRVM(['bundle exec rake db:drop || true'], ruby, name)
     withRVM(['bundle exec rake db:create --trace'], ruby, name)
     withRVM(['RAILS_ENV=production bundle exec rake db:create --trace'], ruby, name)

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -104,7 +104,7 @@ pipeline {
             post {
                 always {
                     dir('foreman') {
-                        archiveArtifacts artifacts: "Gemfile.lock, log/test.log"
+                        archiveArtifacts artifacts: "log/test.log"
                         junit keepLongStdio: true, testResults: 'jenkins/reports/unit/*.xml'
                     }
                 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -136,7 +136,7 @@ pipeline {
             post {
                 always {
                     dir('foreman') {
-                        archiveArtifacts artifacts: "Gemfile.lock, log/test.log"
+                        archiveArtifacts artifacts: "log/test.log"
                         junit keepLongStdio: true, testResults: 'jenkins/reports/unit/*.xml'
                     }
                 }


### PR DESCRIPTION
Katello used to do this individually, but it's easier to be done
directly after calling `bundle install` which we do in configureDatabase