### PR TITLE
allow empty junit results

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -53,7 +53,7 @@ pipeline {
             archiveArtifacts artifacts: 'debug/**/*.xml', allowEmptyArchive: true
 
             step([$class: "TapPublisher", testResults: "debug/**/*.tap"])
-            junit "debug/**/*.xml"
+            junit testResults: "debug/**/*.xml", allowEmptyResults: true
 
             deprovision()
             deleteDir()


### PR DESCRIPTION
not all jobs actually generate junit xml