### PR TITLE
Generate a gemset per executor

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -1,9 +1,13 @@
 def gemset(name = null) {
 
-    def base_name = "${JOB_NAME}-${BUILD_ID}"
+    def base_name = env.BUILD_TAG
+
+    if (EXECUTOR_NUMBER != '0') {
+        base_name += '-' + EXECUTOR_NUMBER
+    }
 
     if (name) {
-        base_name = base_name + '-' + name.replace(".", "-")
+        base_name += '-' + name.replace(".", "-")
     }
 
     base_name


### PR DESCRIPTION
When using parallel pipelines in Jenkins, a single job can run multiple times on the same node. They can be identified by a combination of `BUILD_TAG` (`JOB_NAME`-`BUILD_ID`) and `EXECUTOR_NUMBER`. It can stay simplified if the number is 0. Note they are strings and not integers.