### PR TITLE
Drop phantomjs on slaves

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -188,10 +188,6 @@ class slave (
       ensure   => '1.7.9',
       provider => npm,
     }
-    package { 'phantomjs':
-      ensure   => latest,
-      provider => npm,
-    }
     package { 'grunt-cli':
       ensure   => present,
       provider => npm,


### PR DESCRIPTION
It is no longer needed in tests and doesn't install on recent nodejs versions.