### PR TITLE
Drop kafo_pr scm definition

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/kafo.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/scm/kafo.yaml
@@ -5,13 +5,3 @@
           url: https://github.com/theforeman/kafo.git
           branches:
             - '{branch}'
-
-- scm:
-    name: kafo_pr
-    scm:
-      - git:
-          url: https://github.com/theforeman/kafo.git
-          wipe-workspace: true
-          branches:
-            - '${ghprbActualCommit}'
-          refspec: '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*'


### PR DESCRIPTION
74838a123cb1776aced99aacd656a8a6e651c6d5 rewrote the job to a pipeline but didn't remove the now unused kafo_pr scm definition.