### PR TITLE
Collect smoker logs on all pipelines + refactor

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-katello-test.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-katello-test.yml
@@ -5,6 +5,7 @@
     dsl:
       !include-raw:
         - 'pipelines/lib/foremanCentosJob.groovy{empty}'
+        - 'pipelines/lib/pipelines.groovy{empty}'
         - 'pipelines/test/katello/{version}.groovy'
         - '../theforeman.org/pipelines/lib/ansible.groovy{empty}'
         - '../theforeman.org/pipelines/lib/duffy.groovy{empty}'
@@ -17,6 +18,7 @@
     dsl:
       !include-raw:
         - 'pipelines/lib/foremanCentosJob.groovy{empty}'
+        - 'pipelines/lib/pipelines.groovy{empty}'
         - 'pipelines/test/katello/{version}-upgrade.groovy'
         - '../theforeman.org/pipelines/lib/ansible.groovy{empty}'
         - '../theforeman.org/pipelines/lib/duffy.groovy{empty}'

--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-luna-nightly-test.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-luna-nightly-test.yml
@@ -6,6 +6,7 @@
     dsl:
       !include-raw:
         - pipelines/lib/foremanCentosJob.groovy
+        - pipelines/lib/pipelines.groovy
         - pipelines/test/luna/nightly.groovy
         - ../theforeman.org/pipelines/lib/duffy.groovy
         - ../theforeman.org/pipelines/lib/ansible.groovy

--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-luna-upgrade-nightly-test.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-luna-upgrade-nightly-test.yml
@@ -6,6 +6,7 @@
     dsl:
       !include-raw:
         - pipelines/lib/foremanCentosJob.groovy
+        - pipelines/lib/pipelines.groovy
         - pipelines/test/luna/nightly-upgrade.groovy
         - ../theforeman.org/pipelines/lib/ansible.groovy
         - ../theforeman.org/pipelines/lib/duffy.groovy

--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-nightly-test.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-nightly-test.yml
@@ -6,6 +6,7 @@
     dsl:
       !include-raw:
         - pipelines/lib/foremanCentosJob.groovy{empty}
+        - pipelines/lib/pipelines.groovy{empty}
         - pipelines/test/foreman/nightly-{distro}.groovy
         - ../theforeman.org/pipelines/lib/duffy.groovy{empty}
         - ../theforeman.org/pipelines/lib/ansible.groovy{empty}

--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-release-test.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-release-test.yml
@@ -17,6 +17,7 @@
       !include-raw:
         - pipelines/test/foreman/release.groovy{empty}
         - pipelines/lib/foremanCentosJob.groovy{empty}
+        - pipelines/lib/pipelines.groovy{empty}
         - ../theforeman.org/pipelines/lib/duffy.groovy{empty}
         - ../theforeman.org/pipelines/lib/ansible.groovy{empty}
         - ../theforeman.org/pipelines/lib/foreman_infra.groovy{empty}

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
@@ -1,0 +1,27 @@
+// action, type, version, os, extra_vars = nil
+def pipelineVars(Map args) {
+    if (args.action == 'install') {
+        boxes = ["pipeline-${args.type}-server-${args.version}-${args.os}", "pipeline-${args.type}-smoker-${args.version}-${args.os}"]
+    } else if (args.action == 'upgrade') {
+        boxes = ["pipeline-upgrade-${args.type}-${args.version}-${args.os}", "pipeline-upgrade-${args.type}-smoker-${args.version}-${args.os}"]
+    } else {
+        boxes = []
+    }
+
+    extra_vars = [
+        'pipeline_version': args.version,
+        'pipeline_os': args.os,
+        'pipeline_type': args.type
+    ]
+
+    if (args.extra_vars != null) {
+        extra_vars.update(args.extra_vars)
+    }
+
+    vars = [
+      'boxes': boxes,
+      'pipeline': "${args.action}_pipeline.yml",
+      'extraVars': extra_vars
+    ]
+    return vars
+}

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-centos7.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-centos7.groovy
@@ -1,12 +1,4 @@
 def playBookVars() {
-    playBook = [
-      'boxes': ['pipeline-foreman-server-nightly-centos7', 'pipeline-foreman-smoker-nightly-centos7'],
-      'pipeline': 'install_pipeline.yml',
-      'extraVars': [
-        'pipeline_version': 'nightly',
-        'pipeline_os': 'centos7',
-        'pipeline_type': 'foreman'
-      ]
-    ]
+    playBook = pipelineVars(action: 'install', type: 'foreman', version: 'nightly', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-debian10.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-debian10.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-foreman-server-nightly-debian10'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'debian10', 'pipeline_type': 'foreman']]
+    playBook = pipelineVars(action: 'install', type: 'foreman', version: 'nightly', os: 'debian10')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-debian9.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-debian9.groovy
@@ -1,4 +1,0 @@
-def playBookVars() {
-    playBook = ['boxes': ['pipeline-foreman-server-nightly-debian9'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'debian9', 'pipeline_type': 'foreman']]
-    return playBook
-}

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-ubuntu1804.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/nightly-ubuntu1804.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-foreman-server-nightly-ubuntu1804'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'ubuntu1804', 'pipeline_type': 'foreman']]
+    playBook = pipelineVars(action: 'install', type: 'foreman', version: 'nightly', os: 'ubuntu1804')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/foreman/release.groovy
@@ -1,13 +1,4 @@
 def playBookVars() {
-    playBook = [
-        'boxes': ["pipeline-foreman-server-${params.foreman_version}-${params.distro}"],
-        'pipeline': 'install_pipeline.yml',
-        'extraVars': [
-            'pipeline_version': params.foreman_version,
-            'pipeline_os': params.distro,
-            'pipeline_type': 'foreman',
-            'foreman_expected_version': params.expected_version
-        ]
-    ]
+    playBook = pipelineVars(action: 'install', type: 'foreman', version: params.foreman_version, os: params.distro, extra_vars: ['foreman_expected_version': params.expected_version])
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.12-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.12-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-katello-3.12-centos7'], 'pipeline': 'upgrade_pipeline.yml', 'extraVars': ['pipeline_version': '3.12', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'upgrade', type: 'foreman', version: '3.12', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.12.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.12.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-katello-server-3.12-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': '3.12', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'install', type: 'katello', version: '3.12', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.13-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.13-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-katello-3.13-centos7'], 'pipeline': 'upgrade_pipeline.yml', 'extraVars': ['pipeline_version': '3.13', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'upgrade', type: 'foreman', version: '3.13', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.13.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.13.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-katello-server-3.13-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': '3.13', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'install', type: 'katello', version: '3.13', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.14-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.14-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-katello-3.14-centos7'], 'pipeline': 'upgrade_pipeline.yml', 'extraVars': ['pipeline_version': '3.14', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'upgrade', type: 'foreman', version: '3.14', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.14.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/3.14.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-katello-server-3.14-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': '3.14', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'install', type: 'katello', version: '3.14', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/nightly-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/nightly-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-katello-nightly-centos7'], 'pipeline': 'upgrade_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'upgrade', type: 'katello', version: 'nightly', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/katello/nightly.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-katello-server-nightly-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'centos7', 'pipeline_type': 'katello']]
+    playBook = pipelineVars(action: 'install', type: 'katello', version: 'nightly', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/luna/nightly-upgrade.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/luna/nightly-upgrade.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-upgrade-luna-nightly-centos7'], 'pipeline': 'upgrade_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'centos7', 'pipeline_type': 'luna']]
+    playBook = pipelineVars(action: 'upgrade', type: 'luna', version: 'nightly', os: 'centos7')
     return playBook
 }

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/luna/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/test/luna/nightly.groovy
@@ -1,4 +1,4 @@
 def playBookVars() {
-    playBook = ['boxes': ['pipeline-luna-server-nightly-centos7'], 'pipeline': 'install_pipeline.yml', 'extraVars': ['pipeline_version': 'nightly', 'pipeline_os': 'centos7', 'pipeline_type': 'luna']]
+    playBook = pipelineVars(action: 'upgrade', type: 'luna', version: 'nightly', os: 'centos7')
     return playBook
 }


### PR DESCRIPTION
* a2fd8ac4 Add {install,upgrade}PipelineVars()

All install and upgrade pipelines are the same and this reduces the duplication. It also makes sure that smoker logs are collected in every single pipeline rather than just nightly-centos7.

* 00fd1254 Drop nightly debian9 vars

a1750fa620044620a610ae346ffb3768ea4ad5f3 dropped Debian 9 nightly builds but left this file.