### PR TITLE
Correctly update the extra_vars in pipelines

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
@@ -15,7 +15,7 @@ def pipelineVars(Map args) {
     ]
 
     if (args.extra_vars != null) {
-        extra_vars.update(args.extra_vars)
+        extra_vars.putAll(args.extra_vars)
     }
 
     vars = [


### PR DESCRIPTION
d761823e50c707fdb2fca72230f8f374a8abf7b2 unified the code but uses an invalid method. This corrects the mistake.