### PR TITLE
Use lowercase for release candidates

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/debian/execute_pbuilder.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/debian/execute_pbuilder.sh
@@ -32,7 +32,7 @@ if [[ x$repo =~ ^xdevelop ]]; then
   # Set this in case we need it
   LAST_COMMIT=`curl "${json_url}" | /usr/local/bin/JSON.sh -b | egrep '"lastBuiltRevision","SHA1"' | awk '{print $NF}' | tr -d \" | head -n1`
 else
-  VERSION=`echo ${VERSION} | tr '~rc' '-RC'`
+  VERSION=`echo ${VERSION} | tr '~rc' '-rc'`
   # Download sources
   wget http://downloads.theforeman.org/${project}/${project}-${VERSION}.tar.bz2
   wget http://downloads.theforeman.org/${project}/${project}-${VERSION}.tar.bz2.sig


### PR DESCRIPTION
Starting Foreman 2.0 the convention changed to lowercase. This because Debian was already using lowercase and in RPMs it's also useful because of sorting: RC < develop < rc. That means with lowercase there's no need to bump the release where there is with uppercase.