### PR TITLE
Do not run Ruby 2.0.0 tests for Smart Proxy Plugins

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/smart-proxy-plugin-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/smart-proxy-plugin-pull-request.yaml
@@ -28,7 +28,6 @@
           type: user-defined
           name: ruby
           values:
-            - '2.0.0'
             - '2.5'
             - '2.6'
     builders:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/smart-proxy-plugin.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/smart-proxy-plugin.yaml
@@ -28,7 +28,6 @@
           type: user-defined
           name: ruby
           values:
-            - '2.0.0'
             - '2.5'
             - '2.6'
     builders:


### PR DESCRIPTION
The Proxy is now Ruby 2.5+ so these will fail.