### PR TITLE
Remove unused publisher

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/trigger-release-job.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/publishers/trigger-release-job.yaml
@@ -1,8 +1,0 @@
-- publisher:
-    name: trigger-release-job
-    publishers:
-      - trigger-parameterized-builds:
-        - project: '{job}'
-          condition: SUCCESS
-          predefined-parameters: |
-            git_ref=${{GIT_COMMIT}}


### PR DESCRIPTION
e0243fbc2170aff4398ef0fcd496be6ce6f98c92 removed the last use of this, but didn't remove the publisher itself.