### PR TITLE
Upgrade to nodes to postgresql12

### DIFF
--- a/puppet/modules/slave/manifests/postgresql.pp
+++ b/puppet/modules/slave/manifests/postgresql.pp
@@ -1,5 +1,61 @@
 # @api private
 class slave::postgresql {
+  # only CentOS slaves are used to run unit tests
+  if $facts['os']['family'] == 'RedHat' {
+    if $facts['os']['release']['major'] == '7' {
+
+     ['postgresql-server', 'postgresql-client', 'postgresql'].each |$pkg| {
+        package { "${pkg}-nonscl":
+          ensure  => absent,
+          name    => $pkg,
+          before  => Class['postgresql::globals'],
+        }
+      }
+
+      if $facts['os']['name'] == 'CentOS' {
+        package { 'centos-release-scl-rh':
+          ensure => 'present',
+          before => Class['postgresql::globals'],
+        }
+      } elsif $facts['ec2_metadata'] {
+        yumrepo { 'rhel-server-rhui-rhscl-7-rpms':
+          enabled => true,
+          before => Class['postgresql::globals'],
+        }
+      }
+
+      class { 'postgresql::globals':
+        version              => '12',
+        client_package_name  => 'rh-postgresql12-postgresql-syspaths',
+        server_package_name  => 'rh-postgresql12-postgresql-server-syspaths',
+        contrib_package_name => 'rh-postgresql12-postgresql-contrib-syspaths',
+        service_name         => 'postgresql',
+        datadir              => '/var/opt/rh/rh-postgresql12/lib/pgsql/data',
+        confdir              => '/var/opt/rh/rh-postgresql12/lib/pgsql/data',
+        bindir               => '/usr/bin',
+      }
+    }
+  }
+
+  # Tune DB settings for Jenkins slaves, this is UNSAFE for production!
+  $settings = {
+    'fsync'                        => 'off',
+    'full_page_writes'             => 'off',
+    'synchronous_commit'           => 'off',
+    'autovacuum'                   => 'off',
+    'effective_cache_size'         => '512MB',
+    'shared_buffers'               => '256MB',
+    'checkpoint_completion_target' => '0.9',
+    'wal_level'                    => 'minimal',
+    'max_wal_senders'              => '0',
+  }
+
+  $settings.each |$setting, $value| {
+    postgresql::server::config_entry { $setting:
+      value => $value,
+    }
+  }
+
   Postgresql_psql {
     cwd => '/',
   }
@@ -7,33 +63,15 @@ class slave::postgresql {
   include ::postgresql::client
   include ::postgresql::server
 
+  Class['postgresql::server'] -> Package['postgresql-dev']
+
   # Simple known user/pass that will allow Jenkins to create its
   # own databases when required
   postgresql::server::role { 'foreman':
     password_hash => postgresql_password('foreman', 'foreman'),
     superuser     => true,
     login         => true,
+    require       => Service['postgresql'],
   }
 
-  # only CentOS slaves are used to run unit tests
-  if $::osfamily == 'RedHat' {
-    # Tune DB settings for Jenkins slaves, this is UNSAFE for production!
-    $settings = {
-      'fsync'                        => 'off',
-      'full_page_writes'             => 'off',
-      'synchronous_commit'           => 'off',
-      'autovacuum'                   => 'off',
-      'effective_cache_size'         => '512MB',
-      'shared_buffers'               => '256MB',
-      'checkpoint_segments'          => '20',
-      'checkpoint_completion_target' => '0.9',
-      'wal_level'                    => 'minimal',
-    }
-
-    $settings.each |$setting, $value| {
-      postgresql::server::config_entry { $setting:
-        value => $value,
-      }
-    }
-  }
 }


### PR DESCRIPTION
First attempt at something that works across all our various nodes that run Postgres: CentOS and AWS RHEL. The RHEL on AWS uses RHUI to get it's repositories which have different identifiers than standard RHEL repositories. This also handles removal of older postgresql.

I'm sure there are cleaner ways to handle this logic but I wanted something that I tested and worked to start from. @mmoll @ekohl please tell me how to make this cleaner :)