### PR TITLE
Correctly set nightly_sourcefiles

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -23,7 +23,6 @@ pipeline {
                                 script {
                                     artifact_path = "${pwd()}/artifacts"
                                     copyArtifacts(projectName: source_project_name, target: artifact_path)
-                                    sourcefile_paths = list_files("${artifact_path}/*").findAll { it.endsWith('.gem') || it.endsWith('tar.bz2') || it.endsWith('tar.gz') }
                                     commit_hash = readFile("${artifact_path}/commit")
                                 }
                             }
@@ -44,7 +43,7 @@ pipeline {
                                         packages: obal_package_name,
                                         extraVars: [
                                             'releasers': releasers,
-                                            'nightly_sourcefiles': sourcefile_paths,
+                                            'nightly_sourcefiles': artifact_path,
                                             'nightly_githash': commit_hash
                                         ]
                                     )

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -1,5 +1,4 @@
 def commit_hash = ''
-def sourcefile = ''
 def source_project_name = "${project_name}-${git_ref}-source-release"
 
 pipeline {


### PR DESCRIPTION
In https://ci.theforeman.org/job/katello-master-package-release/1020 this works. Previously it [failed](https://ci.theforeman.org/blue/organizations/jenkins/foreman-installer-develop-package-release/detail/foreman-installer-develop-package-release/324/pipeline/54):

```
[2020-02-24T22:38:56.200Z] TASK [copy source files] *******************************************************
[2020-02-24T22:38:56.200Z] An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
[2020-02-24T22:38:56.200Z] failed: [foreman-installer] (item=foreman-installer-2.1.0-develop.tar.bz2) => changed=false
[2020-02-24T22:38:56.200Z]   ansible_loop_var: item
[2020-02-24T22:38:56.200Z]   item: foreman-installer-2.1.0-develop.tar.bz2
[2020-02-24T22:38:56.200Z]   msg: |-
[2020-02-24T22:38:56.200Z]     Could not find or access 'foreman-installer-2.1.0-develop.tar.bz2'
[2020-02-24T22:38:56.200Z]     Searched in:
[2020-02-24T22:38:56.200Z]             /home/jenkins/workspace/foreman-installer-develop-package-release/obal/obal/data/playbooks/nightly/files/foreman-installer-2.1.0-develop.tar.bz2
[2020-02-24T22:38:56.200Z]             /home/jenkins/workspace/foreman-installer-develop-package-release/obal/obal/data/playbooks/nightly/foreman-installer-2.1.0-develop.tar.bz2
[2020-02-24T22:38:56.200Z]             /home/jenkins/workspace/foreman-installer-develop-package-release/obal/obal/data/playbooks/nightly/files/foreman-installer-2.1.0-develop.tar.bz2
[2020-02-24T22:38:56.200Z]             /home/jenkins/workspace/foreman-installer-develop-package-release/obal/obal/data/playbooks/nightly/foreman-installer-2.1.0-develop.tar.bz2 on the Ansible Controller.
[2020-02-24T22:38:56.200Z]     If you are using a module and expect the file to exist on the remote, see the remote_src option
```