### PR TITLE
Use vars files in source-release jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-installer.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-installer.groovy
@@ -1,8 +1,3 @@
-def commit_hash = ''
-source_type = 'rake'
-foreman_branch = 'develop'
-project_name = 'foreman-installer'
-
 pipeline {
     agent any
 
@@ -15,9 +10,9 @@ pipeline {
     stages {
         stage("Collect Git Hash") {
             steps {
-                git(url: "https://github.com/theforeman/${project_name}", branch: foreman_branch)
+                git url: git_rul, branch: git_ref
                 script {
-                    commit_hash = archive_git_hash()
+                    archive_git_hash()
                 }
             }
         }
@@ -39,7 +34,7 @@ pipeline {
         stage('Build and Archive Source') {
             steps {
                 dir(project_name) {
-                    git url: "https://github.com/theforeman/${project_name}", branch: foreman_branch
+                    git url: git_url, branch: git_ref
                 }
                 script {
                     sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
@@ -49,7 +44,7 @@ pipeline {
         stage('Build Packages') {
             steps {
                 build(
-                    job: "${project_name}-${foreman_branch}-package-release",
+                    job: "${project_name}-${git_ref}-package-release",
                     propagate: false,
                     wait: false
                 )

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-selinux.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-selinux.groovy
@@ -1,8 +1,3 @@
-def commit_hash = ''
-source_type = 'rake'
-foreman_branch = 'develop'
-project_name = 'foreman-selinux'
-
 pipeline {
     agent { label 'el' }
 
@@ -15,9 +10,9 @@ pipeline {
     stages {
         stage("Collect Git Hash") {
             steps {
-                git(url: "https://github.com/theforeman/${project_name}", branch: foreman_branch)
+                git url: git_url, branch: git_ref
                 script {
-                    commit_hash = archive_git_hash()
+                    archive_git_hash()
                 }
             }
         }
@@ -33,17 +28,17 @@ pipeline {
         stage('Build and Archive Source') {
             steps {
                 dir(project_name) {
-                    git url: "https://github.com/theforeman/${project_name}", branch: foreman_branch
+                    git url: git_url, branch: git_ref
                 }
                 script {
-                    sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
+                    generate_sourcefiles(project_name: project_name, source_type: source_type)
                 }
             }
         }
         stage('Build Packages') {
             steps {
                 build(
-                    job: "${project_name}-${foreman_branch}-package-release",
+                    job: "${project_name}-${git_ref}-package-release",
                     propagate: false,
                     wait: false
                 )

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
@@ -1,8 +1,3 @@
-def commit_hash = ''
-foreman_branch = 'develop'
-project_name = 'foreman'
-source_type = 'rake'
-
 pipeline {
     agent { label 'fast' }
 
@@ -24,9 +19,9 @@ pipeline {
                     stages {
                         stage("setup-2.6-postgres") {
                             steps {
-                                git url: 'https://github.com/theforeman/foreman', branch: foreman_branch
+                                git url: git_url, branch: git_ref
                                 script {
-                                    commit_hash = archive_git_hash()
+                                    archive_git_hash()
                                 }
                                 configureRVM(env.RUBY_VER, env.GEMSET)
                                 databaseFile(gemset(env.GEMSET))
@@ -56,10 +51,7 @@ pipeline {
                     stages {
                         stage("setup-2.5-postgres") {
                             steps {
-                                git url: 'https://github.com/theforeman/foreman', branch: foreman_branch
-                                script {
-                                    commit_hash = archive_git_hash()
-                                }
+                                git url: git_url, branch: git_ref
                                 configureRVM(env.RUBY_VER, env.GEMSET)
                                 databaseFile(gemset(env.GEMSET))
                                 configureDatabase(env.RUBY_VER, env.GEMSET)
@@ -88,7 +80,7 @@ pipeline {
                     stages {
                         stage("setup-2.5-postgres-ui") {
                             steps {
-                                git url: 'https://github.com/theforeman/foreman', branch: foreman_branch
+                                git url: git_url, branch: git_ref
                                 configureRVM(env.RUBY_VER, env.GEMSET)
                                 databaseFile(gemset(env.GEMSET))
                                 configureDatabase(env.RUBY_VER, env.GEMSET)
@@ -123,7 +115,7 @@ pipeline {
                     stages {
                         stage("setup-2.5-sqlite3") {
                             steps {
-                                git url: 'https://github.com/theforeman/foreman', branch: foreman_branch
+                                git url: git_url, branch: git_ref
                                 configureRVM(env.RUBY_VER, env.GEMSET)
                                 databaseFile(gemset(env.GEMSET), 'sqlite3')
                                 configureDatabase(env.RUBY_VER, env.GEMSET)
@@ -148,7 +140,7 @@ pipeline {
         stage('Build and Archive Source') {
             steps {
                 dir(project_name) {
-                    git url: "https://github.com/theforeman/${project_name}", branch: foreman_branch
+                    git url: git_url, branch: git_ref
                 }
                 script {
                     sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
@@ -158,7 +150,7 @@ pipeline {
         stage('Build Packages') {
             steps {
                 build(
-                    job: "${project_name}-${foreman_branch}-package-release",
+                    job: "${project_name}-${git_ref}-package-release",
                     propagate: false,
                     wait: false
                 )

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
@@ -1,5 +1,3 @@
-def commit_hash = ''
-
 pipeline {
     agent any
 
@@ -14,7 +12,7 @@ pipeline {
             steps {
                 git(url: git_url, branch: git_ref)
                 script {
-                    commit_hash = archive_git_hash()
+                    archive_git_hash()
                 }
                 add_hammer_cli_git_repos(hammer_cli_git_repos)
             }
@@ -32,7 +30,7 @@ pipeline {
         stage('Build and Archive Source') {
             steps {
                 dir(project_name) {
-                    git url: "https://github.com/theforeman/${project_name}", branch: foreman_branch
+                    git url: git_url, branch: git_ref
                 }
                 script {
                     sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
@@ -42,7 +40,7 @@ pipeline {
         stage('Build Packages') {
             steps {
                 build(
-                    job: "${project_name}-${foreman_branch}-package-release",
+                    job: "${project_name}-${git_ref}-package-release",
                     propagate: false,
                     wait: false
                 )

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -1,9 +1,3 @@
-def commit_hash = ''
-foreman_branch = 'master'
-project_name = 'katello'
-source_type = 'gem'
-ruby = '2.5'
-
 pipeline {
     options {
         timestamps()
@@ -17,9 +11,9 @@ pipeline {
         stage('Setup Git Repos') {
             steps {
                 deleteDir()
-                git url: "https://github.com/Katello/${project_name}", branch: foreman_branch
+                git url: git_url, branch: git_ref
                 script {
-                    commit_hash = archive_git_hash()
+                    archive_git_hash()
                 }
 
                 dir('foreman') {
@@ -127,17 +121,17 @@ pipeline {
         stage('Build and Archive Source') {
             steps {
                 dir(project_name) {
-                    git url: "https://github.com/katello/${project_name}", branch: foreman_branch
+                    git url: git_url, branch: git_ref
                 }
                 script {
-                    sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
+                    generate_sourcefiles(project_name: project_name, source_type: source_type)
                 }
             }
         }
         stage('Build Packages') {
             steps {
                 build(
-                    job: "${project_name}-${foreman_branch}-package-release",
+                    job: "${project_name}-${git_ref}-package-release",
                     propagate: false,
                     wait: false
                 )

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -1,8 +1,3 @@
-def commit_hash = ''
-foreman_branch = 'develop'
-project_name = 'smart-proxy'
-source_type = 'rake'
-
 pipeline {
     agent any
 
@@ -13,12 +8,9 @@ pipeline {
     }
 
     stages {
-        stage("Collect Git Hash") {
+        stage("Clone repository") {
             steps {
-                git(url: 'https://github.com/theforeman/smart-proxy', branch: 'develop')
-                script {
-                    commit_hash = archive_git_hash()
-                }
+                git url: git_url, branch: git_ref
             }
         }
         stage("test ruby-2.5") {
@@ -34,9 +26,10 @@ pipeline {
         stage('Build and Archive Source') {
             steps {
                 dir(project_name) {
-                    git url: "https://github.com/theforeman/${project_name}", branch: foreman_branch
+                    git url: git_url, branch: git_ref
                 }
                 script {
+                    archive_git_hash()
                     sourcefile_paths = generate_sourcefiles(project_name: project_name, source_type: source_type)
                 }
             }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-selinux-develop-test.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-selinux-develop-test.groovy
@@ -1,5 +1,3 @@
-def commit_hash = ''
-
 pipeline {
     agent { label 'el' }
 
@@ -14,7 +12,7 @@ pipeline {
             steps {
                 git(url: 'https://github.com/theforeman/foreman-selinux', branch: 'develop')
                 script {
-                    commit_hash = archive_git_hash()
+                    archive_git_hash()
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-foreman-master.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-foreman-master.groovy
@@ -7,4 +7,3 @@ def build_rpm = true
 def build_deb = false
 def source_type = 'rake'
 def releasers = ['koji-foreman']
-def foreman_branch = 'master'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-katello-master.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-katello-master.groovy
@@ -7,4 +7,3 @@ def build_rpm = true
 def build_deb = false
 def source_type = 'gem'
 def releasers = ['koji-katello']
-def foreman_branch = 'master'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-master.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/hammer-cli-master.groovy
@@ -7,4 +7,3 @@ def build_rpm = true
 def build_deb = false
 def source_type = 'rake'
 def releasers = ['koji-foreman']
-def foreman_branch = 'master'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/katello-master-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/katello-master-release.groovy
@@ -6,3 +6,4 @@ def build_rpm = true
 def build_deb = false
 def source_type = 'gem'
 def releasers = ['koji-katello']
+def ruby = '2.5'

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/smart-proxy-develop-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/smart-proxy-develop-release.groovy
@@ -1,6 +1,6 @@
 def git_url = 'https://github.com/theforeman/smart-proxy.git'
 def git_ref = 'develop'
-def project_name = 'foreman-proxy'
+def project_name = 'smart-proxy'
 def obal_package_name = 'foreman-proxy'
 def build_rpm = true
 def build_deb = true

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-develop-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-develop-source-release.yaml
@@ -10,6 +10,7 @@
       - github
     dsl:
       !include-raw:
+        - pipelines/vars/foreman-develop-release.groovy
         - pipelines/release/source/foreman.groovy
         - pipelines/lib/nightly_packaging.groovy
         - pipelines/lib/foreman_infra.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-installer-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-installer-source-release.yaml
@@ -12,6 +12,7 @@
       - github
     dsl:
       !include-raw:
+        - pipelines/vars/foreman-installer-develop-release.groovy
         - pipelines/release/source/foreman-installer.groovy
         - pipelines/lib/nightly_packaging.groovy
         - pipelines/lib/foreman_infra.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-selinux-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/foreman-selinux-source-release.yaml
@@ -11,6 +11,7 @@
       - github
     dsl:
       !include-raw:
+        - pipelines/vars/foreman-selinux-develop-release.groovy
         - pipelines/release/source/foreman-selinux.groovy
         - pipelines/lib/nightly_packaging.groovy
         - pipelines/lib/foreman_infra.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/katello-master-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/katello-master-source-release.yaml
@@ -10,6 +10,7 @@
       - github
     dsl:
       !include-raw:
+        - pipelines/vars/katello-master-release.groovy
         - pipelines/release/source/katello.groovy
         - pipelines/lib/nightly_packaging.groovy
         - pipelines/lib/foreman_infra.groovy

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/smart-proxy-develop-source-release.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release/source/smart-proxy-develop-source-release.yaml
@@ -11,6 +11,7 @@
       - github
     dsl:
       !include-raw:
+        - pipelines/vars/smart-proxy-develop-release.groovy
         - pipelines/release/source/smart-proxy.groovy
         - pipelines/lib/nightly_packaging.groovy
         - pipelines/lib/foreman_infra.groovy


### PR DESCRIPTION
This also corrects the smart-proxy project_name which fixes its package release job. By making the source and package release use the same vars file, it's much more likely they'll do the same thing.