### PR TITLE
Use obal_package_name as the debian package name

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-x-develop-release.groovy
@@ -61,7 +61,7 @@ pipeline {
                             job: 'release_nightly_build_deb',
                             propagate: true,
                             parameters: [
-                               string(name: 'project', value: project_name),
+                               string(name: 'project', value: obal_package_name),
                                string(name: 'jenkins_job', value: source_project_name),
                             ]
                         )


### PR DESCRIPTION
This technically isn't correct since the hammer packages are different, but those are not built for Debian as nightly packages. However, it is more correct than project_name since smart-proxy != foreman-proxy.