### PR TITLE
Add postgresql-evr package and its repo to unit test slaves

### DIFF
--- a/puppet/modules/slave/manifests/postgresql.pp
+++ b/puppet/modules/slave/manifests/postgresql.pp
@@ -16,6 +16,15 @@ class slave::postgresql {
           ensure => 'present',
           before => Class['postgresql::globals'],
         }
+        yumrepo { 'foreman-infra-el7':
+          baseurl => 'https://yum.theforeman.org/infra/el7/',
+          enabled => true,
+        } ->
+        package { 'rh-postgresql12-postgresql-evr':
+          ensure  => 'present',
+          notify  => Class['postgresql::server::service'],
+          require => Class['postgresql::server::install'],
+        }
       } elsif $facts['ec2_metadata'] {
         yumrepo { 'rhel-server-rhui-rhscl-7-rpms':
           enabled => true,


### PR DESCRIPTION
PR from the discussion here: https://community.theforeman.org/t/adding-postgresql-evr-to-jenkins-slaves/17686/6

A couple notes:

The postgresql-evr package isn't available in nightly yet so I put the staging repo in its place.

`init.pp` was mentioned for configuring the repo but it seemed like just using `yumrepo` in `postgresql.pp` would work based on other examples.
