### PR TITLE
Add missing comma

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-deb.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/foreman-deb.groovy
@@ -17,7 +17,7 @@ pipeline {
                     runCicoJobsInParallel([
                         ['name': 'debian10', 'job': 'foreman-nightly-debian10-test'],
                         ['name': 'debian10-upgrade', 'job': 'foreman-nightly-debian10-upgrade-test'],
-                        ['name': 'ubuntu1804', 'job': 'foreman-nightly-ubuntu1804-test']
+                        ['name': 'ubuntu1804', 'job': 'foreman-nightly-ubuntu1804-test'],
                         ['name': 'ubuntu1804-upgrade', 'job': 'foreman-nightly-ubuntu1804-upgrade-test']
                     ])
                 }


### PR DESCRIPTION
In 988fdc857ca6380ca546760112af2489dca84760 I copied lines but forgot groovy doesn't have trailing a trailing comma and introduced this syntax error.