### PR TITLE
Only keep katello sources for a week

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -3,6 +3,7 @@ pipeline {
         timestamps()
         timeout(time: 2, unit: 'HOURS')
         ansiColor('xterm')
+        buildDiscarder(logRotator(daysToKeepStr: '7'))
     }
 
     agent { label 'fast' }


### PR DESCRIPTION
Currently the katello source job directory is 30 GB because there are a lot of builds. The older ones are never used and can by safely rotated.