### PR TITLE
Add a Jenkins node profile

### DIFF
--- a/puppet/modules/profiles/manifests/jenkins/node.pp
+++ b/puppet/modules/profiles/manifests/jenkins/node.pp
@@ -1,0 +1,27 @@
+# @summary A Jenkins node
+#
+# @param koji_certificate
+#   An optional koji certificate for trusted nodes. Only relevant on Red Hat
+#   based machines.
+#
+# @param swap_size_mb
+#   The swap file size in MBs. Will be unmanaged if set to 0
+class profiles::jenkins::node(
+  Optional[String[1]] $koji_certificate = undef,
+  Integer[0] $swap_size_mb = 8192,
+) {
+  class { 'slave':
+    koji_certificate => $koji_certificate,
+  }
+
+  if $swap_size_mb > 0 {
+    class { 'slave::swap':
+      size_mb => $swap_size_mb,
+    }
+  }
+
+  # Ensure REX can log in
+  class { 'foreman_proxy::plugin::remote_execution::ssh_user':
+    manage_user => true,
+  }
+}

--- a/puppet/modules/slave/files/titorc
+++ b/puppet/modules/slave/files/titorc
@@ -1,1 +1,0 @@
-KOJI_OPTIONS=-c ~/.koji/config build --nowait

--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -10,6 +10,8 @@ class slave (
   Stdlib::Absolutepath $homedir         = '/home/jenkins',
   Stdlib::Absolutepath $workspace       = '/var/lib/workspace',
 ) {
+  include git
+
   # On Debian we use pbuilder with sudo
   $sudo = $facts['osfamily'] ? {
     'Debian' => 'ALL=NOPASSWD: ALL',

--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -1,7 +1,6 @@
 class slave (
   Optional[String] $github_user         = undef,
   Optional[String] $github_oauth        = undef,
-  Optional[String] $jenkins_build_token = undef,
   Optional[String] $koji_certificate    = undef,
   Optional[String] $copr_login          = undef,
   Optional[String] $copr_username       = undef,
@@ -63,7 +62,7 @@ class slave (
     group  => 'jenkins',
   }
 
-  if $github_user and $github_oauth and $jenkins_build_token {
+  if $github_user and $github_oauth {
     file { "${homedir}/.config/hub":
       ensure  => file,
       mode    => '0600',

--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -1,6 +1,4 @@
 class slave (
-  Optional[String] $github_user         = undef,
-  Optional[String] $github_oauth        = undef,
   Optional[String] $koji_certificate    = undef,
   Optional[String] $copr_login          = undef,
   Optional[String] $copr_username       = undef,
@@ -62,18 +60,8 @@ class slave (
     group  => 'jenkins',
   }
 
-  if $github_user and $github_oauth {
-    file { "${homedir}/.config/hub":
-      ensure  => file,
-      mode    => '0600',
-      owner   => 'jenkins',
-      group   => 'jenkins',
-      content => template('slave/hub_config.erb'),
-    }
-  } else {
-    file { "${homedir}/.config/hub":
-      ensure  => absent,
-    }
+  file { "${homedir}/.config/hub":
+    ensure  => absent,
   }
 
   # Build dependencies

--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -1,8 +1,5 @@
 class slave (
   Optional[String] $koji_certificate    = undef,
-  Optional[String] $copr_login          = undef,
-  Optional[String] $copr_username       = undef,
-  Optional[String] $copr_token          = undef,
   Boolean $uploader                     = true,
   Stdlib::Absolutepath $homedir         = '/home/jenkins',
   Stdlib::Absolutepath $workspace       = '/var/lib/workspace',
@@ -60,7 +57,7 @@ class slave (
     group  => 'jenkins',
   }
 
-  file { "${homedir}/.config/hub":
+  file { ["${homedir}/.config/hub", "${homedir}/.config/copr"]:
     ensure  => absent,
   }
 
@@ -271,9 +268,6 @@ class slave (
       class { 'slave::packaging::rpm':
         homedir          => $homedir,
         koji_certificate => $koji_certificate,
-        copr_login       => $copr_login,
-        copr_username    => $copr_username,
-        copr_token       => $copr_token,
       }
       contain slave::packaging::rpm
     }

--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -3,9 +3,6 @@
 class slave::packaging::rpm (
   Stdlib::Absolutepath $homedir,
   Optional[String] $koji_certificate = undef,
-  Optional[String] $copr_login = undef,
-  Optional[String] $copr_username = undef,
-  Optional[String] $copr_token = undef,
 ) {
   package { ['koji', 'rpm-build', 'git-annex', 'pyliblzma', 'createrepo']:
     ensure => latest,
@@ -82,21 +79,6 @@ class slave::packaging::rpm (
     ensure => directory,
     owner  => 'jenkins',
     group  => 'jenkins',
-  }
-
-  # copr
-  if $copr_login {
-    package { 'copr-cli':
-      ensure => latest,
-    }
-
-    file { "${homedir}/.config/copr":
-      ensure  => file,
-      mode    => '0640',
-      owner   => 'jenkins',
-      group   => 'jenkins',
-      content => template('slave/copr.erb'),
-    }
   }
 
   # specs-from-koji

--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -68,11 +68,11 @@ class slave::packaging::rpm (
   }
 
   file { "${homedir}/.titorc":
-    ensure => file,
-    mode   => '0644',
-    owner  => 'jenkins',
-    group  => 'jenkins',
-    source => 'puppet:///modules/slave/titorc',
+    ensure  => file,
+    mode    => '0644',
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    content => "KOJI_OPTIONS=-c ~/.koji/config build --nowait\n",
   }
 
   file { '/tmp/tito':

--- a/puppet/modules/slave/manifests/swap.pp
+++ b/puppet/modules/slave/manifests/swap.pp
@@ -1,4 +1,14 @@
-class slave::swap($file = '/swap', $size_mb = 2048) {
+# @summary Create a swapfile
+#
+# @param file
+#   The location of the swapfile
+#
+# @param size_mb
+#   The size in MBs
+class slave::swap(
+  Stdlib::Absolutepath $file = '/swap',
+  Integer[0] $size_mb = 2048,
+) {
   exec { 'create-swap':
     command => "/bin/dd if=/dev/zero of=${file} bs=1M count=${size_mb}",
     creates => $file,

--- a/puppet/modules/slave/templates/hub_config.erb
+++ b/puppet/modules/slave/templates/hub_config.erb
@@ -1,4 +1,0 @@
----
-github.com:
-- user: <%= @github_user %>
-  oauth_token: <%= @github_oauth %>


### PR DESCRIPTION
The goal of this class is to replace the config group currently used in Foreman. Long term all machines should only be assigned classes from the profiles module and Foreman only imports those classes.

This also removes the hub and copr configs because I believe they are unused.