### PR TITLE
foreman omaha: remove ci job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -72,8 +72,6 @@
           repo: 'https://github.com/theforeman/foreman_host_extra_validator'
       - foreman_monitoring:
           repo: 'https://github.com/theforeman/foreman_monitoring'
-      - foreman_omaha:
-          repo: 'https://github.com/theforeman/foreman_omaha'
       - foreman_openscap:
           repo: 'https://github.com/theforeman/foreman_openscap'
       - foreman_remote_execution:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_omaha.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_omaha.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_omaha
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
This PR removes foreman_omaha from the Jenkins testing as #1017 did not get in. We'll migrate the plugin to Github Actions.