### PR TITLE
Fix deb pushing

### DIFF
--- a/puppet/modules/web/manifests/vhost/deb.pp
+++ b/puppet/modules/web/manifests/vhost/deb.pp
@@ -2,13 +2,13 @@
 # @api private
 class web::vhost::deb (
   String $user = 'freight',
-  Stdlib::Absolutepath $homedir = "/home/${user}",
+  Stdlib::Absolutepath $home = "/home/${user}",
   Boolean $setup_receiver = true,
 ) {
   # Manual step: each user needs the GPG key in it's keyring
   freight::user { 'main':
     user         => $user,
-    home         => $homedir,
+    home         => $home,
     webdir       => '/var/www/vhosts/deb/htdocs',
     stagedir     => '/var/www/freight',
     vhost        => 'deb',
@@ -24,12 +24,12 @@ class web::vhost::deb (
       script_content => template('freight/rsync_main.erb'),
       ssh_key_name   => "rsync_${user}_key",
     }
-    file { "${homedir}/rsync_cache":
+    file { "${home}/rsync_cache":
       ensure => directory,
       owner  => $user,
     }
     # This ruby script is called from the secure_freight template
-    file { "${homedir}/bin/secure_deploy_debs":
+    file { "${home}/bin/secure_deploy_debs":
       ensure  => file,
       owner   => 'freight',
       mode    => '0700',

--- a/puppet/modules/web/manifests/vhost/stagingdeb.pp
+++ b/puppet/modules/web/manifests/vhost/stagingdeb.pp
@@ -2,10 +2,9 @@
 # @api private
 class web::vhost::stagingdeb(
   String $user = 'freightstage',
+  Stdlib::Absolutepath $home = "/home/${user}",
   Boolean $setup_receiver = true,
 ) {
-  $home = "/home/${user}"
-
   # Manual step: each user needs the GPG key in it's keyring
   freight::user { 'staging':
     user         => $user,


### PR DESCRIPTION
20da2b1a98ff33bf8f992d9310620883dcbb601f rewrote the webserve profiles. This broke deb pushing because of the $home variable. 6f8291ad7a3f56c4c77f91aee6064d05cdace3a6 fixed stagingdeb but deb was not fixed correctly. This commit aligns both to use the same method.