### PR TITLE
Pin tito to 0.6.12 to workaround FetchBuilder issue

### DIFF
--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -63,8 +63,10 @@ class slave::packaging::rpm (
   }
 
   # tito
+  # Work around to fix https://github.com/rpm-software-management/tito/pull/354#issuecomment-613523823
+  # Pulled from the infra repository
   package { 'tito':
-    ensure => latest,
+    ensure => '0.6.12',
   }
 
   file { "${homedir}/.titorc":

--- a/puppet/modules/unattended/manifests/init.pp
+++ b/puppet/modules/unattended/manifests/init.pp
@@ -22,7 +22,7 @@ class unattended {
       apply_updates => true,
       mailto        => 'sysadmins',
       extra_configs => {
-        'base/exclude' => { 'value' => 'kernel* java* jenkins' },
+        'base/exclude' => { 'value' => 'kernel* java* jenkins tito' },
       },
     }
   }


### PR DESCRIPTION
Working around this issue https://github.com/rpm-software-management/tito/pull/354#issuecomment-613523823