### PR TITLE
Drop sqlite testing from core PRs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop_pr_core.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop_pr_core.yaml
@@ -34,7 +34,7 @@
             - fast
     execution-strategy:
       combination-filter: >
-        ((database == 'postgresql') && ((ruby == '2.5') || (ruby == '2.6'))) || ((database == 'postgresql-integrations') && (ruby == '2.5'))
+        (database == 'postgresql') || ((database == 'postgresql-integrations') && (ruby == '2.5'))
     builders:
       - shell: !include-raw: scripts/test/test_develop.sh
     publishers:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop_pr_core.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/test_develop_pr_core.yaml
@@ -27,7 +27,6 @@
           values:
             - postgresql-integrations
             - postgresql
-            - sqlite3
       - axis:
           type: label-expression
           name: slave
@@ -35,7 +34,7 @@
             - fast
     execution-strategy:
       combination-filter: >
-        ((database == 'postgresql') && ((ruby == '2.5') || (ruby == '2.6'))) || ((database == 'sqlite3') && (ruby == '2.5')) || ((database == 'postgresql-integrations') && (ruby == '2.5'))
+        ((database == 'postgresql') && ((ruby == '2.5') || (ruby == '2.6'))) || ((database == 'postgresql-integrations') && (ruby == '2.5'))
     builders:
       - shell: !include-raw: scripts/test/test_develop.sh
     publishers:


### PR DESCRIPTION
Rails 6 will not work with the sqlite version shipped in EL7. We are
dropping support for it. Nulldb testing is added in a seperate commit.