### PR TITLE
Increase luna timeout to 4 hours

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/luna.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/luna.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }


### PR DESCRIPTION
upgrade tests can take 3.5 hours to complete.