### PR TITLE
Increase length of centos ci polling

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
@@ -100,7 +100,7 @@
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/api/json"
       register: build_job_result
       until: (build_job_result.json is defined) and (not build_job_result.json.building) and (build_job_result.json.result == 'SUCCESS' or build_job_result.json.result == 'FAILURE' or build_job_result.json.result == 'UNSTABLE')
-      retries: 360
+      retries: 500
       delay: 30
 
     - name: "Create artifacts directory"


### PR DESCRIPTION
Otherwise the polling finishes after ~3 hours, and luna upgrade tests
can take longer.