### PR TITLE
Remove react-ui testing in Katello PRs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -86,15 +86,6 @@ pipeline {
                         }
                     }
                 }
-                stage('react-ui') {
-                    when {
-                        expression { fileExists('package.json') }
-                    }
-                    steps {
-                        sh "npm install"
-                        sh 'npm test'
-                    }
-                }
                 stage('angular-ui') {
                     steps {
                         script {


### PR DESCRIPTION
This removes react testing in Jenkins so we can use dependencies from Foreman and run the testing in GH actions

Related Katello PR: https://github.com/Katello/katello/pull/8722