### PR TITLE
Adds foreman npm install step to Katello

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -48,6 +48,13 @@ pipeline {
 
             }
         }
+        stage('Install Foreman npm packages') {
+            steps {
+                dir('foreman') {
+                    withRVM(["bundle exec npm install"], ruby)
+                }
+            }
+        }
         stage('Run Tests') {
             parallel {
                 stage('tests') {
@@ -90,7 +97,6 @@ pipeline {
                 stage('assets-precompile') {
                     steps {
                         dir('foreman') {
-                            withRVM(["bundle exec npm install"], ruby)
                             withRVM(["bundle exec rake plugin:assets:precompile[${project_name}] RAILS_ENV=production --trace"], ruby)
                         }
                     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -70,6 +70,13 @@ pipeline {
 
             }
         }
+        stage('Install Foreman npm packages') {
+            steps {
+                dir('foreman') {
+                    withRVM(["bundle exec npm install"], ruby)
+                }
+            }
+        }
         stage('Run Tests') {
             parallel {
                 stage('tests') {
@@ -131,7 +138,6 @@ pipeline {
                 stage('assets-precompile') {
                     steps {
                         dir('foreman') {
-                            withRVM(["bundle exec npm install"], ruby)
                             withRVM(['bundle exec rake plugin:assets:precompile[katello] RAILS_ENV=production DATABASE_URL=nulldb://nohost --trace'], ruby)
                         }
                     }


### PR DESCRIPTION
This is related to https://github.com/Katello/katello/pull/8722 - which allows us to use the npm dependencies from Foreman when testing. With that change, we need to install dependencies from Foreman in CI.