### PR TITLE
foreman_expire_hosts: remove ci job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -65,8 +65,6 @@
           repo: 'https://github.com/theforeman/foreman_discovery'
       - foreman_docker:
           repo: 'https://github.com/theforeman/foreman-docker'
-      - foreman_expire_hosts:
-          repo: 'https://github.com/theforeman/foreman_expire_hosts'
       - foreman_host_extra_validator:
           repo: 'https://github.com/theforeman/foreman_host_extra_validator'
       - foreman_monitoring:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_expire_hosts.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_expire_hosts.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_expire_hosts
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
I've opened https://github.com/theforeman/foreman_expire_hosts/pull/63 to migrate tests to GitHub Actions