### PR TITLE
foreman_monitoring: remove ci job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -67,8 +67,6 @@
           repo: 'https://github.com/theforeman/foreman-docker'
       - foreman_host_extra_validator:
           repo: 'https://github.com/theforeman/foreman_host_extra_validator'
-      - foreman_monitoring:
-          repo: 'https://github.com/theforeman/foreman_monitoring'
       - foreman_openscap:
           repo: 'https://github.com/theforeman/foreman_openscap'
       - foreman_salt:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_monitoring.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/plugins/foreman_monitoring.yaml
@@ -1,8 +1,0 @@
-- project:
-    name: foreman_monitoring
-    defaults: plugin
-    branch:
-      - master:
-          foreman_branch: develop
-    jobs:
-      - 'test_plugin_{name}_{branch}'


### PR DESCRIPTION
I've opened https://github.com/theforeman/foreman_monitoring/pull/74 to migrate tests to GitHub Actions