### PR TITLE
clean old ci.centos.org jobs automatically

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/centos_jenkins.ini
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/centos_jenkins.ini
@@ -6,5 +6,5 @@ recursive=True
 allow_duplicates=False
 
 [jenkins]
-url=https://ci.centos.org
+url=https://ci.centos.org/view/Foreman
 query_plugins_info=False

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/infra/updateJobs.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/infra/updateJobs.groovy
@@ -20,7 +20,7 @@ pipeline {
         stage('Update ci.centos.org jobs') {
             steps {
                 withCredentials([string(credentialsId: 'centos-jenkins', variable: 'PASSWORD')]) {
-                    virtEnv('./ci', "cd ./centos.org && jenkins-jobs --conf ./centos_jenkins.ini --user 'foreman' --password '${env.PASSWORD}' update -r ./jobs")
+                    virtEnv('./ci', "cd ./centos.org && jenkins-jobs --conf ./centos_jenkins.ini --user 'foreman' --password '${env.PASSWORD}' update --delete-old -r ./jobs")
                 }
             }
         }


### PR DESCRIPTION
this updates the URL of the jenkins node, as you can reach the API also
*below* a view, but then are limited to that view -- exactly what we
need to delete only our jobs :)