### PR TITLE
only verify release on PRs to develop

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/rpm_packaging.groovy
@@ -59,6 +59,7 @@ pipeline {
         stage("Verify version and release"){
             when {
                 expression { packages_to_build }
+                expression { ghprbTargetBranch == 'rpm/develop' }
             }
             steps {
                 script {


### PR DESCRIPTION
when picking back to stable branches, this will not always be true