### PR TITLE
Add parameter to ci-centos integration test to mirror other tests

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-ci-centos-simple-test.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-ci-centos-simple-test.yml
@@ -4,6 +4,11 @@
     project-type: 'pipeline'
     sandbox: true
     concurrent: true
+    parameters:
+      - string:
+          name: simple_parameter
+          default: simple
+          description: 'A simple parameter for testing'
     dsl:
       !include-raw:
         - pipelines/test/simple.groovy


### PR DESCRIPTION
I think this will also fix: https://ci.theforeman.org/job/ci-centos-integration-test/477/console