### PR TITLE
Use EL8 nodes on CentOS CI

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
@@ -7,6 +7,7 @@
       cico:
         action: get
         api_key: "{{ api_key }}"
+        release: 8
       register: cico_data
 
     - name: 'Retry geting list of nodes'


### PR DESCRIPTION
This is a step in dropping Ruby 2.0 support in forklift. Rather than migrating to SCL or similar, this has the benefit that we get the latest technologies altogether.

It's entirely untested but came from https://github.com/theforeman/forklift/pull/1179#discussion_r451463667