### PR TITLE
Do not test foreman-tasks on Jenkins

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/foreman-plugins-pull-request.yaml
@@ -73,8 +73,6 @@
           repo: 'https://github.com/theforeman/foreman_salt'
       - foreman_setup:
           repo: 'https://github.com/theforeman/foreman_setup'
-      - foreman-tasks:
-          repo: 'https://github.com/theforeman/foreman-tasks'
       - foreman_templates:
           repo: 'https://github.com/theforeman/foreman_templates'
       - foreman_userdata:


### PR DESCRIPTION
https://github.com/theforeman/foreman-tasks/pull/574 is introducing the GH actions, so we don't need to test `foreman-tasks` on Jenkins anymore.