### PR TITLE
Move Katello react tests out of parallel steps

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -48,13 +48,6 @@ pipeline {
 
             }
         }
-        stage('Install Foreman npm packages') {
-            steps {
-                dir('foreman') {
-                    withRVM(["bundle exec npm install"], ruby)
-                }
-            }
-        }
         stage('Run Tests') {
             parallel {
                 stage('tests') {
@@ -71,15 +64,6 @@ pipeline {
                         }
                     }
                 }
-                stage('react-ui') {
-                    when {
-                        expression { fileExists('package.json') }
-                    }
-                    steps {
-                        sh "npm install"
-                        sh 'npm test'
-                    }
-                }
                 stage('angular-ui') {
                     steps {
                         script {
@@ -91,6 +75,21 @@ pipeline {
                                 sh "npm install"
                                 sh "grunt ci"
                             }
+                        }
+                    }
+                }
+                stage('React UI setup and tests') {
+                    agent any
+                    steps {
+                        when {
+                            expression { fileExists('package.json') }
+                        }
+                        dir('foreman') {
+                            withRVM(["bundle exec npm install"], ruby)
+                        }
+                        dir(project_name) {
+                            sh "npm install"
+                            sh 'npm test'
                         }
                     }
                 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/testKatello.groovy
@@ -66,13 +66,6 @@ pipeline {
 
             }
         }
-        stage('Install Foreman npm packages') {
-            steps {
-                dir('foreman') {
-                    withRVM(["bundle exec npm install"], ruby)
-                }
-            }
-        }
         stage('Run Tests') {
             parallel {
                 stage('tests') {
@@ -87,15 +80,6 @@ pipeline {
                         dir('foreman') {
                             withRVM(['bundle exec rake katello:rubocop TESTOPTS="-v" --trace'], ruby)
                         }
-                    }
-                }
-                stage('react-ui') {
-                    when {
-                        expression { fileExists('package.json') }
-                    }
-                    steps {
-                        sh "npm install"
-                        sh 'npm test'
                     }
                 }
                 stage('angular-ui') {
@@ -128,6 +112,21 @@ pipeline {
                                     sh "grunt ci"
                                 }
                             }
+                        }
+                    }
+                }
+                stage('React UI setup and tests') {
+                    agent any
+                    steps {
+                        when {
+                            expression { fileExists('package.json') }
+                        }
+                        dir('foreman') {
+                            withRVM(["bundle exec npm install"], ruby)
+                        }
+                        dir(project_name) {
+                            sh "npm install"
+                            sh 'npm test'
                         }
                     }
                 }


### PR DESCRIPTION
With the addition of functional tests that use a lot of asynchronous actions, we are seeing timeout issues for these tests in Jenkins but not in GH actions. Moving them out of the parallel steps should help to address these timeout issues. We have already increased the timeouts for jest, react-testing-lib, and nock.

The goal is to remove the react tests (and foreman npm install step) from the PR job and only keep it in the nightly/release job. This would allow us to rely on GH actions in PRs and speed up the jenkins job. I think it is a good idea to see the tests run successfully for a few days in the new non-parallel step before removing it, so we can be sure there won't be issues during the release jobs.