### PR TITLE
make stagingdeb homedir world-readable

### DIFF
--- a/puppet/modules/secure_ssh/manifests/receiver_setup.pp
+++ b/puppet/modules/secure_ssh/manifests/receiver_setup.pp
@@ -21,8 +21,10 @@
 #
 define secure_ssh::receiver_setup (
   String $user,
+  Array[String] $groups = [],
   String $script_content,
   Stdlib::Absolutepath $homedir = "/home/${user}",
+  Stdlib::Filemode $homedir_mode = '0700',
   Optional[String] $foreman_search = undef,
   Array[Stdlib::IP::Address] $allowed_ips = [],
   String $ssh_key_name = "${name}_key",
@@ -34,12 +36,14 @@ define secure_ssh::receiver_setup (
     home       => $homedir,
     managehome => true,
     password   => '!',
+    groups     => $groups,
   }
 
   # Created above, but this ensures futher chaining is correct
   file { $homedir:
     ensure => directory,
     owner  => $user,
+    mode   => $homedir_mode,
   }
 
   file { "${homedir}/.ssh":

--- a/puppet/modules/secure_ssh/manifests/rsync/receiver_setup.pp
+++ b/puppet/modules/secure_ssh/manifests/rsync/receiver_setup.pp
@@ -21,14 +21,18 @@
 #
 define secure_ssh::rsync::receiver_setup (
   String $user,
+  Array[String] $groups = [],
   Stdlib::Absolutepath $homedir = "/home/${user}",
+  Stdlib::Filemode $homedir_mode = '0700',
   Optional[String] $foreman_search = undef,
   Array[Stdlib::IP::Address] $allowed_ips = [],
   String $script_content = "# Permit transfer\n\$SSH_ORIGINAL_COMMAND\n",
 ) {
   secure_ssh::receiver_setup { $name:
     user           => $user,
+    groups         => $groups,
     homedir        => $homedir,
+    homedir_mode   => $homedir_mode,
     foreman_search => $foreman_search,
     allowed_ips    => $allowed_ips,
     ssh_key_name   => "rsync_${name}_key",

--- a/puppet/modules/web/manifests/vhost/deb.pp
+++ b/puppet/modules/web/manifests/vhost/deb.pp
@@ -20,6 +20,8 @@ class web::vhost::deb (
     # script to handle deployment too
     secure_ssh::receiver_setup { $user:
       user           => $user,
+      groups         => ['freightstage'],
+      homedir        => $home,
       foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
       script_content => template('freight/rsync_main.erb'),
       ssh_key_name   => "rsync_${user}_key",
@@ -35,5 +37,7 @@ class web::vhost::deb (
       mode    => '0700',
       content => template('freight/deploy_debs.erb'),
     }
+
+    User <| title == 'freightstage' |> -> User <| title == $user |>
   }
 }

--- a/puppet/modules/web/manifests/vhost/stagingdeb.pp
+++ b/puppet/modules/web/manifests/vhost/stagingdeb.pp
@@ -18,6 +18,8 @@ class web::vhost::stagingdeb(
   if $setup_receiver {
     secure_ssh::rsync::receiver_setup { $user:
       user           => $user,
+      homedir        => $home,
+      homedir_mode   => '0750',
       foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
       script_content => template('freight/rsync.erb'),
     }


### PR DESCRIPTION
the main deb user needs to be able to read it.

secrets (ssh, gpg) are still secure as their folders have stricter perms