### PR TITLE
Add Foreman and Overview docs

### DIFF
--- a/docs/foreman-puppetserver.md
+++ b/docs/foreman-puppetserver.md
@@ -1,0 +1,20 @@
+# Foreman and Puppet Server
+
+Foreman and Puppet are used to manage every machine in the Foreman infrastructure. The Foreman instance is accessible only to those with SSH access to puppetmaster.theforeman.org. Add the following snippet to `~/.ssh/config`:
+
+```
+Host foreman-pm
+  HostName puppetmaster.theforeman.org
+  Port 8122
+  User <your SSH user>
+  LocalForward 9443 localhost:443
+  ExitOnForwardFailure yes
+```
+
+and then run:
+
+```
+ssh foreman-pm
+```
+
+and open https://localhost:9443 in your browser.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,50 @@
+# Overview
+
+The Foreman project runs a number of different servers for testing, packaging, and continuous integration.
+
+## Access
+
+Access to Foreman project infrastructure is available for those who wish to assist in building packages, testing, and building Jenkins jobs.
+
+Fork https://github.com/theforeman/foreman-infra and add your key into the [files directory](https://github.com/theforeman/foreman-infra/tree/master/puppet/modules/users/files) of the [`users` module](https://github.com/theforeman/foreman-infra/blob/master/puppet/modules/users/). Submit a pull request to the infrastructure project and send a post to the [Infra SIG discourse thread](https://community.theforeman.org/c/development/infra/24). One of them can merge your change and add your user in the Foreman web UI.
+
+## Landscape
+
+| Role | Provider(s) |
+|---|---|
+| [Jenkins](./docs/jenkins.md) | OSUOSL |
+| [Koji](./docs/koji.md) | AWS |
+| [Jenkins Nodes](./docs/jenkins.md)  | OSUOSL / AWS |
+
+## Infrastructure providers
+
+A list of the hosting we have, who provides it, and what capacity it has
+
+* Rackspace
+  * Previously sponsored, [being phased out](https://community.theforeman.org/t/rfc-moving-off-of-rackspace-infrastructure/17932)
+  * Hosts Jenkins
+  * Contact support from our account as needed
+* Scaleway
+  * Previously sponsored, planned to be phased out
+  * Support usually helpful, Edouard Bonlieu & Yann Léger were initial contacts
+  * Hosts Discourse, Redmine, ARM Jenkins nodes
+* Fastly
+  * Sponsored
+  * $1k/month CDN
+  * Elaine Greenberg was initial contact
+* OSUOSL
+  * Sponsored
+  * Hosts test machines, Jenkins nodes, and web01
+  * Contact Lance Alberston if more capacity is needed
+* NETWAYS
+  * Sponsored
+  * Openstack instance for spinning up as needed compute
+  * Option to add an Icinga Monitoring host here, talk to Dirk to progress
+* Gandi
+  * Sponsors theforeman.org domain
+* Individual contributors
+  * Variety of single VMs, see the Foreman Dashboard for details
+* CentOS
+  * Sponsored
+  * Provides Jenkins and bare metal hardware for running pipeline testing
+


### PR DESCRIPTION
Replaces:

 * https://projects.theforeman.org/projects/foreman/wiki/Infrastructure

This is scant information to start with as I am porting the wiki pages over first for review, and to allow brain dumps of knowledge.

