### PR TITLE
Retry provisioning of a ci.centos.org node

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/provision.yml
@@ -7,10 +7,8 @@
       cico:
         action: get
         api_key: "{{ api_key }}"
+        retry_count: 5
       register: cico_get_data
-      retries: 5
-      delay: 5
-      until: cico_get_data.results.ssid
 
     - name: 'Fail if no SSID returned'
       fail:


### PR DESCRIPTION
Based on:

```
+ ansible-playbook -i localhost provision.yml
 [WARNING]: Unable to parse /home/foreman/workspace/foreman-pipeline-
katello-3.17-centos7-install/foreman-
infra/puppet/modules/jenkins_job_builder/files/centos.org/ansible/localhost as
an inventory source
 [WARNING]: No inventory was parsed, only implicit localhost is available
 [WARNING]: Could not match supplied host pattern, ignoring: all
 [WARNING]: provided hosts list is empty, only localhost is available

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Get a new node] **********************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'cico_get_data.results.ssid' failed. The error was: error while evaluating conditional (cico_get_data.results.ssid): 'dict object' has no attribute 'results'"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```