### PR TITLE
match all jenkins-master nodes

### DIFF
--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -1,4 +1,4 @@
-node 'jenkins-master' {
+node /^jenkins-master.*/ {
   include jenkins_master
 
   class { 'web::base':


### PR DESCRIPTION
for some reason, this didn't match my FQDN host today:

    Error: Could not find node statement with name 'default' or 'jenkins-master.yatsu.example.com' on node jenkins-master.yatsu.example.com