### PR TITLE
allow running ansible playbooks in a virtualenv

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
@@ -32,7 +32,7 @@ def runPlaybook(args) {
         command.push("-e @${sensitive_extra_vars_file}")
     }
 
-    command_string = "${command.join(' ')}"
+    command_string = command.join(' ')
 
     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
         if (venv) {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
@@ -38,7 +38,7 @@ def runPlaybook(args) {
         if (venv) {
             virtEnv(venv, command_string)
         } else {
-            sh "${command_string}"
+            sh command_string
         }
     }
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/ansible.groovy
@@ -5,6 +5,7 @@ def runPlaybook(args) {
     sensitiveExtraVars = args.sensitiveExtraVars ?: [:]
     options = args.options ?: []
     commandLineExtraVars = args.commandLineExtraVars ?: false
+    venv = args.venv
 
     def command = [
         "ansible-playbook",
@@ -31,8 +32,14 @@ def runPlaybook(args) {
         command.push("-e @${sensitive_extra_vars_file}")
     }
 
+    command_string = "${command.join(' ')}"
+
     wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
-        sh "${command.join(' ')}"
+        if (venv) {
+            virtEnv(venv, command_string)
+        } else {
+            sh "${command_string}"
+        }
     }
 }
 


### PR DESCRIPTION
We had implemented that once already, but then reverted because it
behaved weirdly. I can't reproduce the bad behaviour anymore, so let's
try this again.

Revert "Revert "allow running ansible playbooks in a virtualenv""

This reverts commit ad573df4439ebb33f1c91e29b51815297accb338.