### PR TITLE
stop polling after *any* job result

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/ansible/jenkins_job.yml
@@ -82,7 +82,7 @@
         content: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/"
       when: jenkins_job_link_file is defined
 
-    - name: "Poll job until success or fail"
+    - name: "Poll job until it finished"
       uri:
         force_basic_auth: yes
         headers:
@@ -94,7 +94,7 @@
         password: "{{ jenkins_password }}"
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/api/json"
       register: build_job_result
-      until: (build_job_result.json is defined) and (not build_job_result.json.building) and (build_job_result.json.result == 'SUCCESS' or build_job_result.json.result == 'FAILURE' or build_job_result.json.result == 'UNSTABLE')
+      until: (build_job_result.json is defined) and (not build_job_result.json.building) and (build_job_result.json.result|len > 0)
       retries: 500
       delay: 30
 
@@ -107,10 +107,13 @@
     - name: "Fetch remote artifacts"
       get_url:
         url: "{{ jenkins_host }}/job/{{ jenkins_job_name }}/{{ poll_result.json.executable.number }}/artifact/{{ item.relativePath }}"
-        dest: "{{ jenkins_artifacts_directory}}/{{ item.fileName }}"
+        dest: "{{ jenkins_artifacts_directory }}/{{ item.fileName }}"
       loop: "{{ build_job_result.json.artifacts }}"
       when: jenkins_download_artifacts | bool
 
-    - fail:
+    - name: "Fail if the build failed"
+      fail:
         msg: "Build Job Failed"
-      when: build_job_result.json.result == 'FAILURE'
+      when:
+        - build_job_result.json.result != 'SUCCESS'
+        - build_job_result.json.result != 'UNSTABLE'


### PR DESCRIPTION
we only need to know if the job finished at all (or was aborted)