### PR TITLE
remove all user debs after 7 days

### DIFF
--- a/puppet/modules/freight/templates/cron.erb
+++ b/puppet/modules/freight/templates/cron.erb
@@ -49,11 +49,13 @@ package_names.each do |pn,archs|
   # pn is something like "apt/wheezy/nightly/foreman-proxy"
   # archs is ['all'] or ['amd64', 'i386']
 
+  owner_is_foreman = pn.split('/')[2].start_with?('theforeman-')
+
   archs.each do |arch|
     packages = raw_files.map { |f| f if f.match /^#{pn}_.*_#{arch}.deb/ }.compact
 
     packages.sort! {|x,y| File.mtime(x) <=> File.mtime(y)}
-    packages.delete_at(-1) # Always leave at least one file
+    packages.delete_at(-1) if owner_is_foreman # Always leave at least one file for foreman
     packages.delete_if { |f| File.mtime(f) > $time }
 
     files_to_remove += packages


### PR DESCRIPTION
the old logic always kept "one version" of every package, which can
result in broken PR builds if a user does the following:
1. build package_a with a bug and never builds a fixed version
2. tries to build package_b that depends on package_a