### PR TITLE
Treat web01 repo failures as fatal

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
@@ -9,7 +9,7 @@ void push_rpms(repo_src, repo_dest, version, distro) {
 
 void push_rpms_direct(repo_source, repo_dest, overwrite = true, merge = false) {
     sshagent(['repo-sync']) {
-        sh "ssh yumrepo@web01.osuosl.theforeman.org ${repo_source} ${repo_dest} ${overwrite} ${merge} || true"
+        sh "ssh yumrepo@web01.osuosl.theforeman.org ${repo_source} ${repo_dest} ${overwrite} ${merge}"
     }
 }
 


### PR DESCRIPTION
3e379fb5d1ef376f0a8e06171de7cd58b4004389 added web01 syncs as optional, but 5f2568a88b3761f5b2d88e6668fccbe30d761a40 removed web02. This means we should not treat failures as fatal.