### PR TITLE
Remove custom-job-icon and cvs plugins from Jenkins

### DIFF
--- a/puppet/modules/jenkins_master/manifests/init.pp
+++ b/puppet/modules/jenkins_master/manifests/init.pp
@@ -64,7 +64,6 @@ class jenkins_master {
     'create-fingerprint'                 => {},
     'credentials'                        => {},
     'credentials-binding'                => {},
-    'cvs'                                => {},
     'dashboard-view'                     => {},
     'data-tables-api'                    => {},
     'display-url-api'                    => {},

--- a/puppet/modules/jenkins_master/manifests/init.pp
+++ b/puppet/modules/jenkins_master/manifests/init.pp
@@ -64,7 +64,6 @@ class jenkins_master {
     'create-fingerprint'                 => {},
     'credentials'                        => {},
     'credentials-binding'                => {},
-    'custom-job-icon'                    => {},
     'cvs'                                => {},
     'dashboard-view'                     => {},
     'data-tables-api'                    => {},


### PR DESCRIPTION
We don't use this plugin and it contains an XSS exploit with a patch available.