### PR TITLE
Add ci.theforeman.org jobs to the update jobs job

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/foreman_jenkins.ini
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/foreman_jenkins.ini
@@ -1,0 +1,10 @@
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.
+recursive=True
+allow_duplicates=False
+
+[jenkins]
+url=https://ci.theforeman.org/
+query_plugins_info=False

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/infra/updateJobs.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/infra/updateJobs.groovy
@@ -17,6 +17,14 @@ pipeline {
             }
         }
 
+        stage('Update ci.theforeman.org jobs') {
+            steps {
+                withCredentials([string(credentialsId: 'theforeman-jenkins', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                    virtEnv('jjb-venv', "cd ./ci/theforeman.org && jenkins-jobs --conf ./foreman_jenkins.ini --user ${env.USERNAME} --password '${env.PASSWORD}' update --delete-old -r .")
+                }
+            }
+        }
+
         stage('Update ci.centos.org jobs') {
             steps {
                 withCredentials([string(credentialsId: 'centos-jenkins', variable: 'PASSWORD')]) {


### PR DESCRIPTION
The credentials will need to be created and added if the structure is agreed upon. After this PR, we can then:

 * move the creation of this job to the puppet module
 * move the bulk of the JJB configurations to a top level directory