### PR TITLE
Fix in check with mashing

### DIFF
--- a/koji/collection-mash-split.py
+++ b/koji/collection-mash-split.py
@@ -417,7 +417,7 @@ def main():
         else:
             git_tag = "rpm/{}".format(version)
 
-            if version in ('2.0'):
+            if version in ['2.0']:
                 dists['fedora29'] = 'fc29'
 
         mashes = [MashConfig(collection, version, dist, dist, code) for dist, code in dists.items()]


### PR DESCRIPTION
2d26531f97e94d79c23a7ec905b5202f4b992c29 dropped 1.24, but in doing so the tuple changed into simple braces. That means the in check was changed to a substring check. While it may work, it's not really correct and can break later.