### PR TITLE
Unify Foreman RPM release process

### DIFF
--- a/koji/collection-mash-split.py
+++ b/koji/collection-mash-split.py
@@ -398,7 +398,7 @@ def main():
         else:
             extras = []
 
-        mashes = [MashConfig(collection, version, "rhel7-dist", "rhel7", "RHEL/7", extras)]
+        mashes = [MashConfig(collection, version, "rhel7-dist", "rhel7", "el7", extras)]
 
         if LooseVersion(version) > LooseVersion('2.0'):
             mashes.append(MashConfig(collection, version, "el8", "el8", "RHEL/8"))

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/release.groovy
@@ -1,6 +1,13 @@
-void push_foreman_rpms(repo_type, version, distro) {
+void push_foreman_rpms(repo_type, version, distros) {
     version = version == 'develop' ? 'nightly' : version
-    push_rpms("foreman-${repo_type}-${version}", repo_type, version, distro)
+    keep_old_files = version != 'nightly'
+    for (distro in distros) {
+        if repo_type {
+            push_rpms("foreman-${repo_type}-${version}", repo_type, version, distro, keep_old_files)
+        } else {
+            push_rpms_direct("foreman-${version}/${distro}", "releases/${version}/${distro}", false, true)
+        }
+    }
 }
 
 void push_rpms(repo_src, repo_dest, version, distro, keep_old_files = false) {

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/client.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/client.groovy
@@ -44,9 +44,7 @@ pipeline {
 
             steps {
                 script {
-                    foreman_client_distros.each { distro ->
-                        push_foreman_rpms('client', foreman_version, distro)
-                    }
+                    push_foreman_rpms('client', foreman_version, foreman_client_distros)
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
@@ -45,7 +45,7 @@ pipeline {
             steps {
                 script {
                     for (release in foreman_el_releases) {
-                        push_rpms_direct("foreman-${foreman_version}/RHEL/${release.replace('el', '')}", "releases/${foreman_version}/${release}", false, true)
+                        push_rpms_direct("foreman-${foreman_version}/${release}", "releases/${foreman_version}/${release}", false, true)
                     }
                 }
             }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
@@ -44,9 +44,7 @@ pipeline {
 
             steps {
                 script {
-                    for (release in foreman_el_releases) {
-                        push_rpms_direct("foreman-${foreman_version}/${release}", "releases/${foreman_version}/${release}", false, true)
-                    }
+                    push_foreman_rpms(nil, foreman_version, foreman_el_releases)
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -43,8 +43,9 @@ pipeline {
         stage('Push RPMs') {
             agent { label 'admin && sshkey' }
             steps {
-                push_rpms_direct("foreman-nightly/el7", "nightly/el7")
-                push_rpms_direct("foreman-nightly/el8", "nightly/el8")
+                script {
+                    push_foreman_rpms(nil, foreman_version, foreman_el_releases)
+                }
             }
         }
     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -43,8 +43,8 @@ pipeline {
         stage('Push RPMs') {
             agent { label 'admin && sshkey' }
             steps {
-                push_rpms_direct("foreman-nightly/RHEL/7", "nightly/el7")
-                push_rpms_direct("foreman-nightly/RHEL/8", "nightly/el8")
+                push_rpms_direct("foreman-nightly/el7", "nightly/el7")
+                push_rpms_direct("foreman-nightly/el8", "nightly/el8")
             }
         }
     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -13,7 +13,7 @@ pipeline {
             agent { label 'sshkey' }
 
             steps {
-                mash('foreman', 'nightly')
+                mash('foreman', foreman_version)
             }
         }
         stage('Repoclosure') {
@@ -35,6 +35,7 @@ pipeline {
 
             steps {
                 script {
+                    // TODO: derive rpm_pipelines from pipelines (as defined in nightly)
                     def rpm_pipelines = ['install': ['centos7', 'centos8'], 'upgrade': ['centos7', 'centos8']]
                     runCicoPipelines('foreman', foreman_version, rpm_pipelines)
                 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins.groovy
@@ -35,11 +35,7 @@ pipeline {
 
             steps {
                 script {
-                    def overwrite = foreman_version == 'nightly'
-                    def merge = foreman_version != 'nightly'
-                    for (release in foreman_el_releases) {
-                        push_rpms_direct("foreman-plugins-${foreman_version}/${release}", "plugins/${foreman_version}/${release}", overwrite, merge)
-                    }
+                    push_foreman_rpms('plugins', foreman_version, foreman_el_releases)
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins.groovy
@@ -38,7 +38,7 @@ pipeline {
                     def overwrite = foreman_version == 'nightly'
                     def merge = foreman_version != 'nightly'
                     for (release in foreman_el_releases) {
-                        push_rpms_direct("foreman-plugins-${foreman_version}/RHEL/${release.replace('el', '')}", "plugins/${foreman_version}/${release}", overwrite, merge)
+                        push_rpms_direct("foreman-plugins-${foreman_version}/${release}", "plugins/${foreman_version}/${release}", overwrite, merge)
                     }
                 }
             }


### PR DESCRIPTION
In most places the elX convention is used, but foreman repos are the exception in using RHEL/X. This change aligns all which uses. It doesn't contain any code to move the existing directories. While it's technically not needed and it'll work, it would waste a lot of disk space.

It then standardizes all pushes by using a common function to reduce duplication.