### PR TITLE
Drop ARM builds

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_deb.sh
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/scripts/test/packaging_test_pull_request_deb.sh
@@ -35,9 +35,6 @@ EOF
   elif [[ $p == foreman* ]] ; then
     echo "nightly_jenkins_job=$p-develop-source-release" >> test_builds/debian/${p}.properties
   fi
-  if [[ ${ghprbTargetBranch} == deb/2.1 ]] || [[ ${ghprbTargetBranch} == deb/develop ]]; then
-    echo "onlyarch=x86" >> test_builds/debian/${p}.properties
-  fi
 done
 
 # identify changed dependencies, 5 at most!

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_coreproject.yaml
@@ -19,14 +19,13 @@
           name: arch
           values:
           - x86
-          - armv8
       - axis:
           type: slave
           name: label
           values:
           - debian
     execution-strategy:
-      combination-filter: '(onlyarch == "all" || onlyarch == arch) && (onlyos == "all" || onlyos == os) && !((version == "2.2" || version == "2.1" || version == "nightly") && arch == "armv8")'
+      combination-filter: '(onlyos == "all" || onlyos == os)'
     builders:
       - build_deb_coreproject
     publishers:
@@ -52,13 +51,6 @@ Any value other than "theforeman" will be pushed to http://stagingdeb.theforeman
             - bionic
             - focal
           description: 'Restrict matrix job to just the one OS.'
-      - choice:
-          name: onlyarch
-          choices:
-            - all
-            - x86
-            - armv8
-          description: 'Restrict matrix job to just the one arch.'
       - string:
           name: repo
           default: develop

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_dependency.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/packaging_build_deb_dependency.yaml
@@ -23,14 +23,13 @@
           name: arch
           values:
           - x86
-          - armv8
       - axis:
           type: slave
           name: label
           values:
           - debian
     execution-strategy:
-      combination-filter: '(onlyos == "all" || onlyos == os) && !((version == "2.2" || version == "2.1" || version == "2.0" ) && os == "focal") && !((version == "2.2" || version == "2.1" || version == "nightly") && arch == "armv8")'
+      combination-filter: '(onlyos == "all" || onlyos == os) && !((version == "2.2" || version == "2.1" || version == "2.0" ) && os == "focal")'
     builders:
       - build_deb_dependency
     publishers:

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_build_deb.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/release_nightly_build_deb.yaml
@@ -12,7 +12,6 @@
           predefined-parameters: |
             repoowner=theforeman
             project=${project}
-            onlyarch=x86
             onlyos=all
             repo=develop
             version=nightly


### PR DESCRIPTION
Version 2.0 was the last that supported these, but that's now EOL. This allows us to clean up the unsupported builders.