### PR TITLE
publish tap results downloaded from cico

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman_infra.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/foreman_infra.groovy
@@ -58,6 +58,7 @@ def runIndividualCicoJob(job_name, number = 0, job_parameters = null, job_extra_
             if (extra_vars['jenkins_artifacts_directory']) {
                 def relative_artifacts_directory = extra_vars['jenkins_artifacts_directory'].replace("${env.WORKSPACE}/", '')
                 archiveArtifacts artifacts: "${relative_artifacts_directory}/**", allowEmptyArchive: true
+                step([$class: "TapPublisher", testResults: "${relative_artifacts_directory}/**/*.tap", failIfNoResults: false])
             }
             set_job_build_description(job_name, status, link_file_name)
         }


### PR DESCRIPTION
much easier to read than the plain output (or navigating to
ci.centos.org)