### PR TITLE
Ensure jobs cannot configure global bundler config

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -55,6 +55,19 @@ class slave (
     ensure  => absent,
   }
 
+  file { "${homedir}/.bundle":
+    ensure  => directory,
+    owner   => root,
+    group   => root,
+  }
+
+  file { "${homedir}/.bundle/config":
+    ensure  => file,
+    owner   => root,
+    group   => root,
+    content => '',
+  }
+
   # Build dependencies
   $libxml2_dev = $facts['os']['family'] ? {
     'RedHat' => 'libxml2-devel',


### PR DESCRIPTION
When testing new job configs, global bundle configurations can be
accidentally created and break existing jobs. This change ensures
that this file does not exist on the Jenkins nodes.


Something in the past couple of days started creating the following:

```
---
BUNDLE_WITHOUT: "development"
```

This leads to some tests breaking such as Kafo PRs: https://ci.theforeman.org/job/kafo-pr-test/201/consoleFull