### PR TITLE
Drop old RVM versions

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -13,20 +13,20 @@ def gemset(name = null) {
     base_name
 }
 
-def configureRVM(ruby = '2.0', name = '') {
+def configureRVM(ruby, name = '') {
     emptyGemset(ruby, name)
     withRVM(["gem install bundler -v '< 2.0'"], ruby, name)
 }
 
-def emptyGemset(ruby = '2.0', name = '') {
+def emptyGemset(ruby, name = '') {
     withRVM(["rvm gemset empty ${gemset(name)} --force"], ruby, name)
 }
 
-def cleanupRVM(ruby = '2.0', name = '') {
+def cleanupRVM(ruby, name = '') {
     withRVM(["rvm gemset delete ${gemset(name)} --force"], ruby, name)
 }
 
-def withRVM(commands, ruby = '2.0', name = '') {
+def withRVM(commands, ruby, name = '') {
 
     commands = commands.join("\n")
     echo commands.toString()

--- a/puppet/modules/slave/manifests/rvm.pp
+++ b/puppet/modules/slave/manifests/rvm.pp
@@ -18,23 +18,6 @@ class slave::rvm {
       require => User['jenkins'],
     }
 
-    if $facts['os']['architecture'] == 'x86_64' or $facts['os']['architecture'] == 'amd64' {
-      slave::rvm_config { 'ruby-2.0.0':
-        version          => 'ruby-2.0.0-p648',
-        rubygems_version => '2.7.10',
-      }
-    }
-    slave::rvm_config { 'ruby-2.1':
-      version          => 'ruby-2.1.5',
-      rubygems_version => '2.7.10',
-    }
-    slave::rvm_config { 'ruby-2.2':
-      version          => 'ruby-2.2.5',
-      rubygems_version => '2.7.10',
-    }
-    slave::rvm_config { 'ruby-2.3':
-      version => 'ruby-2.3.5',
-    }
     slave::rvm_config { 'ruby-2.4':
       version => 'ruby-2.4.3',
     }


### PR DESCRIPTION
RVM is not able to install these versions anymore so they're not guaranteed to be available.

This also drops the default Ruby version which forces usage to be explicit about the Ruby version.

Currently this is blocked on https://github.com/theforeman/foreman-infra/pull/1476 which removes the last uses of these RVM versions.