### PR TITLE
Make withRVM fatal

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -32,7 +32,7 @@ def withRVM(commands, ruby, name = '') {
     echo commands.toString()
 
     sh """#!/bin/bash -l
-        set +e
+        set -e
         rvm use ruby-${ruby}@${gemset(name)} --create
         ${commands}
     """


### PR DESCRIPTION
set +e disables the mode while set -e enables it. This allows it to fail fast when the RVM gemset can't be created.