### PR TITLE
Fix foreman-installer tests that rely on checking for log

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-installer.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/test/foreman-installer.groovy
@@ -52,11 +52,8 @@ pipeline {
                             }
                             withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec rake install PREFIX=${install_dir} --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
                             withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-installer --help --scenario foreman --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            sh "cat ${install_dir}/var/log/foreman-installer/foreman.log"
                             withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-installer --help --scenario foreman-proxy-content --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            sh "cat ${install_dir}/var/log/foreman-installer/foreman-proxy-content.log"
                             withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-installer --help --scenario katello --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
-                            sh "cat ${install_dir}/var/log/foreman-installer/katello.log"
                             withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-proxy-certs-generate --help --trace"], ruby, "${ruby}-${PUPPET_VERSION}")
                             withRVM(["BUNDLE_GEMFILE=Gemfile.${ruby}-${PUPPET_VERSION} bundle exec ${install_dir}/sbin/foreman-proxy-certs-generate --help|grep -q certs-update-server"], ruby, "${ruby}-${PUPPET_VERSION}")
                         }


### PR DESCRIPTION
In newer Kafo versions, --help does not generate an initial empty
log file and thus we should not rely on it for test validation. The
fact that --help does not error should be sufficient.