### PR TITLE
use job_name-build_number instead of build_tag

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/lib/rvm.groovy
@@ -1,6 +1,6 @@
 def gemset(name = null) {
 
-    def base_name = env.BUILD_TAG
+    def base_name = "${JOB_NAME}-${BUILD_NUMBER}"
 
     if (EXECUTOR_NUMBER != '0') {
         base_name += '-' + EXECUTOR_NUMBER


### PR DESCRIPTION
build_tag is defined as "jenkins-${JOB_NAME}-${BUILD_NUMBER}" which
produces too long DB names and the "jenkins" prefix is not really
telling anything as *everything* is run by jenkins here