### PR TITLE
adjust test pipeline timeouts to 4 hours

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-deb.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-deb.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/katello.groovy
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         disableConcurrentBuilds()
         ansiColor('xterm')
     }


### PR DESCRIPTION
the underlying polling for ci.centos.org is configured for roughly 4h,
so timing this job out earlier is nonsense