### PR TITLE
Fix pipeline box names

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
@@ -1,9 +1,9 @@
 // action, type, version, os, extra_vars = nil
 def pipelineVars(Map args) {
     if (args.action == 'install') {
-        boxes = ["pipe-${args.type}-server-${args.version}-${args.os}", "pipeline-${args.type}-proxy-${args.version}-${args.os}", "pipeline-${args.type}-smoker-${args.version}-${args.os}"]
+        boxes = ["pipe-${args.type}-server-${args.version}-${args.os}", "pipe-${args.type}-proxy-${args.version}-${args.os}", "pipe-${args.type}-smoker-${args.version}-${args.os}"]
     } else if (args.action == 'upgrade') {
-        boxes = ["pipe-up-${args.type}-${args.version}-${args.os}", "pipeline-up-${args.type}-proxy-${args.version}-${args.os}", "pipeline-up-${args.type}-smoker-${args.version}-${args.os}"]
+        boxes = ["pipe-up-${args.type}-${args.version}-${args.os}", "pipe-up-${args.type}-proxy-${args.version}-${args.os}", "pipe-up-${args.type}-smoker-${args.version}-${args.os}"]
     } else {
         boxes = []
     }


### PR DESCRIPTION
3d24ecf3695dec14a68458467e075fe651d63b89 renamed the primary box, but forgot the rest of the boxes. This meant that junit.xml was no longer archived.