### PR TITLE
use commandline extra vars on centos ci

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -32,7 +32,8 @@ pipeline {
                         playbook: 'playbooks/setup_forklift.yml',
                         inventory: cico_inventory('./'),
                         options: ['-b'],
-                        extraVars: setup_extra_vars
+                        extraVars: setup_extra_vars,
+                        commandLineExtraVars: true,
                     )
                 }
             }


### PR DESCRIPTION
in d935d81 we forgot that we can't use writeYaml on ci.centos.org