### PR TITLE
fallback to "all" boxes, instead of none

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
@@ -5,7 +5,7 @@ def pipelineVars(Map args) {
     } else if (args.action == 'upgrade') {
         boxes = ["pipe-up-${args.type}-${args.version}-${args.os}", "pipe-up-${args.type}-proxy-${args.version}-${args.os}", "pipe-up-${args.type}-smoker-${args.version}-${args.os}"]
     } else {
-        boxes = []
+        boxes = ["all"]
     }
 
     extra_vars = [


### PR DESCRIPTION
otherwise you get errors like this:

    $ ansible-playbook playbooks/collect_debug.yml -l   -e pipeline_version=3.7 -e pipeline_os=centos8 -e pipeline_type=pulpcore -e foreman_expected_version=
    ansible-playbook: error: argument -l/--limit: expected one argument

which is not what we want as a fallback :)