### PR TITLE
collect debug from all machines that are named pipe-*

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/foremanCentosJob.groovy
@@ -60,7 +60,7 @@ pipeline {
         always {
             script {
                 extra_vars = buildExtraVars(extraVars: playBook['extraVars'])
-                duffy_ssh("cd forklift && ansible-playbook playbooks/collect_debug.yml -l ${playBook['boxes'].join(',')} ${extra_vars}", 'duffy_box', './')
+                duffy_ssh("cd forklift && ansible-playbook playbooks/collect_debug.yml --limit '${playBook['boxes'].join(',')}' ${extra_vars}", 'duffy_box', './')
                 runPlaybook(
                     playbook: 'foreman-infra/ci/centos.org/ansible/fetch_debug_files.yml',
                     inventory: cico_inventory('./'),

--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/lib/pipelines.groovy
@@ -1,12 +1,6 @@
 // action, type, version, os, extra_vars = nil
 def pipelineVars(Map args) {
-    if (args.action == 'install') {
-        boxes = ["pipe-${args.type}-server-${args.version}-${args.os}", "pipe-${args.type}-proxy-${args.version}-${args.os}", "pipe-${args.type}-smoker-${args.version}-${args.os}"]
-    } else if (args.action == 'upgrade') {
-        boxes = ["pipe-up-${args.type}-${args.version}-${args.os}", "pipe-up-${args.type}-proxy-${args.version}-${args.os}", "pipe-up-${args.type}-smoker-${args.version}-${args.os}"]
-    } else {
-        boxes = ["all"]
-    }
+    boxes = ["pipe-*"]
 
     extra_vars = [
         'pipeline_version': args.version,


### PR DESCRIPTION
in #1547 we made the fallback "all", but also discussed that the whole
if/else logic might be obsolete.
"all" is not a perfect fallback as this also runs collect debug against
other hosts defined in the inventory -- especially the hypervisor we run
our tests on.
however we can use a "pipe-*" pattern to match all hosts belonging to
the pipeline and only fetch data from those.