### PR TITLE
trigger nightly package builds in post

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-installer.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-installer.groovy
@@ -32,20 +32,20 @@ pipeline {
                 }
             }
         }
-        stage('Build Packages') {
-            steps {
-                build(
-                    job: "${project_name}-${git_ref}-package-release",
-                    propagate: false,
-                    wait: false
-                )
-            }
-        }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
+
         always {
             deleteDir()
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-selinux.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman-selinux.groovy
@@ -36,20 +36,20 @@ pipeline {
                 }
             }
         }
-        stage('Build Packages') {
-            steps {
-                build(
-                    job: "${project_name}-${git_ref}-package-release",
-                    propagate: false,
-                    wait: false
-                )
-            }
-        }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
+
         always {
             deleteDir()
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/foreman.groovy
@@ -176,21 +176,22 @@ pipeline {
                 }
             }
         }
-        stage('Build Packages') {
-            steps {
-                build(
-                    job: "${project_name}-${git_ref}-package-release",
-                    propagate: false,
-                    wait: false
-                )
-            }
-        }
     }
 
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
+
         always {
             deleteDir()
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/hammer-cli-x.groovy
@@ -43,20 +43,20 @@ pipeline {
                 }
             }
         }
-        stage('Build Packages') {
-            steps {
-                build(
-                    job: "${project_name}-${git_ref}-package-release",
-                    propagate: false,
-                    wait: false
-                )
-            }
-        }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
+
         always {
             deleteDir()
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/katello.groovy
@@ -135,21 +135,21 @@ pipeline {
                 }
             }
         }
-        stage('Build Packages') {
-            steps {
-                build(
-                    job: "${project_name}-${git_ref}-package-release",
-                    propagate: false,
-                    wait: false
-                )
-            }
-        }
     }
 
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
+
         always {
             dir('foreman') {
                 cleanup(ruby)

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/source/smart-proxy.groovy
@@ -40,20 +40,20 @@ pipeline {
                 }
             }
         }
-        stage('Build Packages') {
-            steps {
-                build(
-                    job: "${project_name}-${git_ref}-package-release",
-                    propagate: false,
-                    wait: false
-                )
-            }
-        }
     }
     post {
+        success {
+            build(
+                job: "${project_name}-${git_ref}-package-release",
+                propagate: false,
+                wait: false
+            )
+        }
+
         failure {
             notifyDiscourse(env, "${project_name} source release pipeline failed:", currentBuild.description)
         }
+
         always {
             deleteDir()
         }


### PR DESCRIPTION
package release takes the last successfull source release as the source
for the artifacts, but when we trigger in a stage step, the source
release is not finished yet and package release will take the *previous*
successfull source release as the source, thus not actually building
what it was triggered for.