### PR TITLE
install vagrant-scp for FDI jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/foreman-discovery-image-build.groovy
+++ b/puppet/modules/jenkins_job_builder/files/centos.org/pipelines/foreman-discovery-image-build.groovy
@@ -23,6 +23,8 @@ pipeline {
                 runPlaybook(
                     playbook: 'playbooks/setup_forklift.yml',
                     inventory: cico_inventory('./'),
+                    extraVars: ['vagrant_scp': true],
+                    commandLineExtraVars: true,
                 )
             }
         }


### PR DESCRIPTION
this was disabled in https://github.com/theforeman/forklift/pull/1270, but we forgot the FDI jobs :see_no_evil: 