### PR TITLE
split plugins test pipeline

### DIFF
--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-deb.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-deb.groovy
@@ -14,8 +14,7 @@ pipeline {
 
             steps {
                 script {
-                    def deb_pipelines = ['install': ['debian10', 'ubuntu1804'], 'upgrade': ['debian10', 'ubuntu1804']]
-                    runCicoPipelines('foreman', foreman_version, deb_pipelines)
+                    runCicoPipelines('foreman', foreman_version, pipelines_deb)
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-pipeline.groovy
@@ -72,7 +72,8 @@ pipeline {
 
     post {
         success {
-          build job: "foreman-plugins-${foreman_version}-test-pipeline", wait: false
+          build job: "foreman-plugins-${foreman_version}-rpm-test-pipeline", wait: false
+          build job: "foreman-plugins-${foreman_version}-deb-test-pipeline", wait: false
         }
     }
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/foreman-rpm.groovy
@@ -35,8 +35,7 @@ pipeline {
 
             steps {
                 script {
-                    def rpm_pipelines = ['install': ['centos7', 'centos8'], 'upgrade': ['centos7', 'centos8']]
-                    runCicoPipelines('foreman', foreman_version, rpm_pipelines)
+                    runCicoPipelines('foreman', foreman_version, pipelines_el)
                 }
             }
         }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins-deb.groovy
@@ -14,7 +14,7 @@ pipeline {
 
             steps {
                 script {
-                    runCicoPipelines('plugins', foreman_version, pipelines)
+                    runCicoPipelines('plugins', foreman_version, pipelines_deb)
                 }
             }
         }
@@ -22,7 +22,7 @@ pipeline {
 
     post {
         failure {
-            notifyDiscourse(env, "Foreman ${foreman_version} Plugins Test pipeline failed:", currentBuild.description)
+            notifyDiscourse(env, "Foreman ${foreman_version} Plugins DEB Test pipeline failed:", currentBuild.description)
         }
     }
 }

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/release/pipelines/plugins-rpm.groovy
@@ -1,0 +1,28 @@
+pipeline {
+    agent none
+
+    options {
+        timestamps()
+        timeout(time: 2, unit: 'HOURS')
+        disableConcurrentBuilds()
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage('Install Test') {
+            agent any
+
+            steps {
+                script {
+                    runCicoPipelines('plugins', foreman_version, pipelines_el)
+                }
+            }
+        }
+    }
+
+    post {
+        failure {
+            notifyDiscourse(env, "Foreman ${foreman_version} Plugins RPM Test pipeline failed:", currentBuild.description)
+        }
+    }
+}

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/2.2.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/2.2.groovy
@@ -12,17 +12,30 @@ def foreman_el_releases = [
     'el8'
 ]
 def foreman_debian_releases = ['buster', 'bionic']
-def pipelines = [
+
+def pipelines_deb = [
     'install': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ],
     'upgrade': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ]
+]
+
+def pipelines_el = [
+    'install': [
+        'centos7',
+        'centos8',
+    ],
+    'upgrade': [
+        'centos7',
+        'centos8',
+    ]
+]
+
+def pipelines = [
+    'install': pipelines_deb['install'] + pipelines_el['install'],
+    'upgrade': pipelines_deb['upgrade'] + pipelines_el['upgrade'],
 ]

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/2.3.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/2.3.groovy
@@ -11,17 +11,30 @@ def foreman_el_releases = [
     'el8'
 ]
 def foreman_debian_releases = ['buster', 'bionic']
-def pipelines = [
+
+def pipelines_deb = [
     'install': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ],
     'upgrade': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ]
+]
+
+def pipelines_el = [
+    'install': [
+        'centos7',
+        'centos8',
+    ],
+    'upgrade': [
+        'centos7',
+        'centos8',
+    ]
+]
+
+def pipelines = [
+    'install': pipelines_deb['install'] + pipelines_el['install'],
+    'upgrade': pipelines_deb['upgrade'] + pipelines_el['upgrade'],
 ]

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/2.4.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/2.4.groovy
@@ -11,17 +11,30 @@ def foreman_el_releases = [
     'el8'
 ]
 def foreman_debian_releases = ['buster', 'bionic']
-def pipelines = [
+
+def pipelines_deb = [
     'install': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ],
     'upgrade': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ]
+]
+
+def pipelines_el = [
+    'install': [
+        'centos7',
+        'centos8',
+    ],
+    'upgrade': [
+        'centos7',
+        'centos8',
+    ]
+]
+
+def pipelines = [
+    'install': pipelines_deb['install'] + pipelines_el['install'],
+    'upgrade': pipelines_deb['upgrade'] + pipelines_el['upgrade'],
 ]

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/nightly.groovy
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/pipelines/vars/foreman/nightly.groovy
@@ -12,17 +12,30 @@ def foreman_el_releases = [
     'el8'
 ]
 def foreman_debian_releases = ['buster', 'bionic']
-def pipelines = [
+
+def pipelines_deb = [
     'install': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ],
     'upgrade': [
-        'centos7',
-        'centos8',
         'debian10',
         'ubuntu1804'
     ]
+]
+
+def pipelines_el = [
+    'install': [
+        'centos7',
+        'centos8',
+    ],
+    'upgrade': [
+        'centos7',
+        'centos8',
+    ]
+]
+
+def pipelines = [
+    'install': pipelines_deb['install'] + pipelines_el['install'],
+    'upgrade': pipelines_deb['upgrade'] + pipelines_el['upgrade'],
 ]

--- a/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/pipeline/foreman-release-pipelines.yaml
+++ b/puppet/modules/jenkins_job_builder/files/theforeman.org/yaml/jobs/pipeline/foreman-release-pipelines.yaml
@@ -53,13 +53,24 @@
         - 'pipelines/lib/foreman_infra.groovy{empty}'
 
 - job-template:
-    name: 'foreman-plugins-{version}-test-pipeline'
+    name: 'foreman-plugins-{version}-rpm-test-pipeline'
     project-type: pipeline
     sandbox: true
     dsl:
       !include-raw:
         - 'pipelines/vars/foreman/{version}.groovy'
-        - 'pipelines/release/pipelines/plugins-pipeline.groovy{empty}'
+        - 'pipelines/release/pipelines/plugins-rpm.groovy{empty}'
+        - 'pipelines/lib/ansible.groovy{empty}'
+        - 'pipelines/lib/foreman_infra.groovy{empty}'
+
+- job-template:
+    name: 'foreman-plugins-{version}-deb-test-pipeline'
+    project-type: pipeline
+    sandbox: true
+    dsl:
+      !include-raw:
+        - 'pipelines/vars/foreman/{version}.groovy'
+        - 'pipelines/release/pipelines/plugins-deb.groovy{empty}'
         - 'pipelines/lib/ansible.groovy{empty}'
         - 'pipelines/lib/foreman_infra.groovy{empty}'
 
@@ -69,7 +80,8 @@
       - 'foreman-{version}-release-pipeline'
       - 'foreman-client-{version}-rpm-pipeline'
       - 'foreman-plugins-{version}-rpm-pipeline'
-      - 'foreman-plugins-{version}-test-pipeline'
+      - 'foreman-plugins-{version}-rpm-test-pipeline'
+      - 'foreman-plugins-{version}-deb-test-pipeline'
     empty: ''
     version:
       !include: ../../includes/foreman_versions.yaml.inc
@@ -80,7 +92,8 @@
     jobs:
       - 'foreman-client-{version}-rpm-pipeline'
       - 'foreman-plugins-{version}-rpm-pipeline'
-      - 'foreman-plugins-{version}-test-pipeline'
+      - 'foreman-plugins-{version}-rpm-test-pipeline'
+      - 'foreman-plugins-{version}-deb-test-pipeline'
     empty: ''
     version:
       - 'nightly'


### PR DESCRIPTION
this splits the pipeline definitions into EL and DEB, and uses that to create two plugin tests pipes

if that works as intended, I plan to also split the regular release pipes like this, following what we do in nightly