### PR TITLE
run jenkins_cleaner as root

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -281,6 +281,6 @@ class slave (
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
-    content => "#!/bin/sh\nrunuser -u jenkins -- find ${workspace} /usr/local/rvm/gems/ -maxdepth 1 -mindepth 1 -type d -user jenkins -ctime +3 -exec rm -rf {} +\n", # lint:ignore:140chars
+    content => "#!/bin/sh\nfind ${workspace} /usr/local/rvm/gems/ -maxdepth 1 -mindepth 1 -type d -user jenkins -ctime +3 -exec rm -rf {} +\n", # lint:ignore:140chars
   }
 }


### PR DESCRIPTION
the way git annex creates files/folders, they can't be removed by the
owner as the owner lack write permissions to the folders.