### PR TITLE
kill perl:5.30 from the flattened repos

### DIFF
--- a/koji/flatten-el8/rhel8-split.sh
+++ b/koji/flatten-el8/rhel8-split.sh
@@ -69,6 +69,7 @@ for ARCH in ${ARCHES}; do
     rm -rf ruby\:2.6*
     rm -rf ruby\:2.7*
     rm -rf nodejs\:14*
+    rm -rf perl\:5.30*
     # Mergerepo didn't work so lets just createrepo in the top directory.
     createrepo_c .  &> /dev/null
     popd


### PR DESCRIPTION
perl 5.26 is in Base, not AppStream, but thanks to our flattened layout,
we inject 5.30, which overrides 5.26 from base and breaks stuff.