### PR TITLE
install pip on debian packaging nodes

### DIFF
--- a/puppet/modules/slave/manifests/packaging/debian.pp
+++ b/puppet/modules/slave/manifests/packaging/debian.pp
@@ -10,6 +10,8 @@ class slave::packaging::debian(
     ensure => present,
   }
 
+  ensure_packages(['python-pip', 'python-setuptools'])
+
   include apt::backports
 
   Class['Apt::Backports'] ->


### PR DESCRIPTION
this is required to download with pip which we now do :)