### PR TITLE
purge debian nightly builds after 3 days

### DIFF
--- a/puppet/modules/freight/templates/cron.erb
+++ b/puppet/modules/freight/templates/cron.erb
@@ -16,7 +16,7 @@ end
 exit unless ENV['VARLIB']
 
 Dir.chdir(ENV['VARLIB'])
-$time = Time.now - (60*60*24*7)  # 7 days ago
+$time = Time.now - (60*60*24*3)  # 3 days ago
 
 raw_files = []
 # Globs


### PR DESCRIPTION
nobody really looks at old builds, and 7 days accumulates too much cruft
and eats up diskspace