### PR TITLE
Correct API docs redirect

### DIFF
--- a/puppet/modules/web/manifests/vhost/web.pp
+++ b/puppet/modules/web/manifests/vhost/web.pp
@@ -27,7 +27,7 @@ class web::vhost::web(
     { 'rewrite_rule' => ['^/events/all.ics https://community.theforeman.org/c/events/l/calendar.ics [R,L]'] },
     { 'rewrite_rule' => ['^/events/? https://community.theforeman.org/c/events/l/calendar [R,L]'] },
     { 'rewrite_rule' => ["^/api/latest(.*) https://apidocs.theforeman.org/foreman/${stable}\$1 [R,L]"] },
-    { 'rewrite_rule' => ['^/api/(.*) https://apidocs.theforeman.org/foreman/\$1 [R,L]'] },
+    { 'rewrite_rule' => ['^/api/(.*) https://apidocs.theforeman.org/foreman/$1 [R,L]'] },
     { 'rewrite_rule' => ['^/api$ https://apidocs.theforeman.org/foreman/ [R,L]'] },
   ]
 


### PR DESCRIPTION
In c7c69ae4ec77d794f536ffe13bb8ea728dd0dba5 the apidoc redirect was made. However, it copied a line with variables and then changed to single quotes. That meant escaping was no longer needed. The result:

```console
$ curl https://theforeman.org/api/2.4/apidoc/v2/compute_profiles/create.html -si | grep Location
Location: https://apidocs.theforeman.org/foreman/$1
```