### PR TITLE
Remove unmaintained flow plugin

### DIFF
--- a/puppet/modules/jenkins_master/manifests/init.pp
+++ b/puppet/modules/jenkins_master/manifests/init.pp
@@ -41,7 +41,6 @@ class jenkins_master {
     'bootstrap4-api'                     => {},
     'bouncycastle-api'                   => {},
     'branch-api'                         => {},
-    'build-flow-plugin'                  => {'version' => '0.20'},
     'build-keeper-plugin'                => {},
     'build-timeout'                      => {},
     'build-timestamp'                    => {},


### PR DESCRIPTION
This plugin contains security problems and we don't use it anymore.

I already removed this from production.