### PR TITLE
Avoid apt-key in our deb instructions

### DIFF
--- a/puppet/modules/freight/files/archivedeb-HEADER.html
+++ b/puppet/modules/freight/files/archivedeb-HEADER.html
@@ -16,7 +16,7 @@ deb http://archivedeb.theforeman.org/ plugins &lt;version&gt;
 <p>An example of how to add it:</p>
 
 <pre>
-wget https://archivedeb.theforeman.org/foreman.asc -O - | apt-key add
+wget https://archivedeb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
 echo "deb http://archivedeb.theforeman.org/ buster 1.24" > /etc/apt/sources.list.d/foreman.list
 echo "deb http://archivedeb.theforeman.org/ plugins 1.24" >> /etc/apt/sources.list.d/foreman.list
 </pre>

--- a/puppet/modules/freight/files/deb-HEADER.html
+++ b/puppet/modules/freight/files/deb-HEADER.html
@@ -19,7 +19,7 @@ deb http://deb.theforeman.org/ plugins nightly
 <p>An example of how to add it:</p>
 
 <pre>
-wget https://deb.theforeman.org/foreman.asc -O - | apt-key add
+wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
 echo "deb http://deb.theforeman.org/ buster nightly" > /etc/apt/sources.list.d/foreman.list
 echo "deb http://deb.theforeman.org/ plugins nightly" >> /etc/apt/sources.list.d/foreman.list
 </pre>


### PR DESCRIPTION
https://blog.jak-linux.org/2021/06/20/migrating-away-apt-key/ describes how a key can be added to /etc/apt/trusted.gpg.d instead of using apt-key.