### PR TITLE
Add a link to el8/foreman-release.rpm on yum.t.o

### DIFF
--- a/puppet/modules/web/files/yum/HEADER.html
+++ b/puppet/modules/web/files/yum/HEADER.html
@@ -14,6 +14,7 @@
 
 <ul>
   <li><a href="https://yum.theforeman.org/releases/latest/el7/x86_64/foreman-release.rpm">https://yum.theforeman.org/releases/latest/el7/x86_64/foreman-release.rpm</a></li>
+  <li><a href="https://yum.theforeman.org/releases/latest/el8/x86_64/foreman-release.rpm">https://yum.theforeman.org/releases/latest/el8/x86_64/foreman-release.rpm</a></li>
 </ul>
 
 <p>Release packages <a href="https://theforeman.org/security.html#GPGkeys">are signed with a new key for each major release</a>.  The public key is available in the RPM-GPG-KEY-foreman file within each version directory or the foreman-release RPMs.</p>


### PR DESCRIPTION
We've always linked to the foreman-release RPM, but prior to this we only listed EL7. This makes it easier to install the foreman-release RPM on EL8.