### PR TITLE
Add a header to yum.t.o/pulpcore & update yum.t.o header

### DIFF
--- a/puppet/modules/web/files/yum/HEADER.html
+++ b/puppet/modules/web/files/yum/HEADER.html
@@ -1,13 +1,14 @@
 <h1>yum.theforeman.org</h1>
-<body>
 
 <h3>Stable Foreman releases</h3>
 
 <p>Releases are available under <code>/releases/VERSION/DIST/ARCH</code>, e.g.</p>
 
 <ul>
-  <li>/releases/1.17/el7/x86_64</li>
+  <li>/releases/2.5/el7/x86_64</li>
+  <li>/releases/2.5/el8/x86_64</li>
   <li>/releases/nightly/el7/x86_64</li>
+  <li>/releases/nightly/el8/x86_64</li>
 </ul>
 
 <p>foreman-release RPMs containing an appropriate .repo file are available with fixed URLs:</p>
@@ -34,8 +35,10 @@
 <p>Plugin repos are structured by the Foreman version that they're compatible with in the format <code>/plugins/VERSION/DIST/ARCH</code>, e.g.</p>
 
 <ul>
-  <li>/plugins/1.17/el7/x86_64</li>
+  <li>/plugins/2.5/el7/x86_64</li>
+  <li>/plugins/2.5/el8/x86_64</li>
   <li>/plugins/nightly/el7/x86_64</li>
+  <li>/plugins/nightly/el8/x86_64</li>
 </ul>
 
 <p>Plugin repos are not GPG signed.</p>

--- a/puppet/modules/web/files/yum/pulpcore-HEADER.html
+++ b/puppet/modules/web/files/yum/pulpcore-HEADER.html
@@ -1,0 +1,3 @@
+<h1>Pulpcore packages</h1>
+
+These are RPM builds for [Pulp 3](https://pulpproject.org) and various plugins for use by [Katello](https://theforeman.org/plugins/katello/). They are only intended to be used by Katello. Only branches used by Katello are maintained. No explicit end of life announcements will be made.

--- a/puppet/modules/web/files/yum/pulpcore-HEADER.html
+++ b/puppet/modules/web/files/yum/pulpcore-HEADER.html
@@ -1,3 +1,3 @@
 <h1>Pulpcore packages</h1>
 
-These are RPM builds for [Pulp 3](https://pulpproject.org) and various plugins for use by [Katello](https://theforeman.org/plugins/katello/). They are only intended to be used by Katello. Only branches used by Katello are maintained. No explicit end of life announcements will be made.
+These are RPM builds for <a href="https://pulpproject.org">Pulp 3</a> and various plugins for use by <a href="https://theforeman.org/plugins/katello/">Katello</a>. They are only intended to be used by Katello. Only branches used by Katello are maintained. No explicit end of life announcements will be made.

--- a/puppet/modules/web/manifests/vhost/yum.pp
+++ b/puppet/modules/web/manifests/vhost/yum.pp
@@ -105,4 +105,19 @@ class web::vhost::yum (
     ensure => link,
     target => '../nightly',
   }
+
+  file { "${yum_directory}/pulpcore":
+    ensure => directory,
+    owner  => $user,
+    group  => $user,
+    mode   => '0755',
+  }
+
+  file { "${yum_directory}/pulpcore/HEADER.html":
+    ensure  => file,
+    owner   => $user,
+    group   => $user,
+    mode    => '0644',
+    content => file('web/yum/pulpcore-HEADER.html'),
+  }
 }


### PR DESCRIPTION
This explains the intent and support policy for Pulpcore packages.

93e4aa7cc94555dfba124193df7187ccd3428588 started to fix the HTML structure of the existing yum header but left in a spurious body tag. It also updates the version to the latest and adds EL8 examples.