### PR TITLE
Correct typo in Fastly-Soft-Purge header

### DIFF
--- a/puppet/modules/web/files/fastly-purge.sh
+++ b/puppet/modules/web/files/fastly-purge.sh
@@ -7,5 +7,5 @@ BASE=${1}
 shift
 
 for purge in $@; do
-  curl --silent -X PURGE -H 'Fastly-Saft-Purge:1' ${BASE}/${purge}
+  curl --silent -X PURGE -H 'Fastly-Soft-Purge:1' ${BASE}/${purge}
 done


### PR DESCRIPTION
https://docs.fastly.com/en/guides/soft-purges

Fixes: 875bb689ce2d52697de7c9a077719f33844143c0