### PR TITLE
Add F99printrepos and C10foremanlog hooks for pbuilder

### DIFF
--- a/puppet/modules/slave/files/pbuilder_C10foremanlog
+++ b/puppet/modules/slave/files/pbuilder_C10foremanlog
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Read Foreman package installation logs on failure
+cat /var/log/foreman-install.log || true

--- a/puppet/modules/slave/files/pbuilder_F99printrepos
+++ b/puppet/modules/slave/files/pbuilder_F99printrepos
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+tail -n 100 /etc/apt/sources.list /etc/apt/sources.list.d/*.list

--- a/puppet/modules/slave/manifests/pbuilder_setup.pp
+++ b/puppet/modules/slave/manifests/pbuilder_setup.pp
@@ -46,6 +46,18 @@ define slave::pbuilder_setup (
     content => file('slave/pbuilder_D80no-man-db-rebuild'),
   }
 
+  file { "/etc/pbuilder/${name}/hooks/C10foremanlog":
+    ensure  => $ensure,
+    mode    => '0775',
+    content => file('slave/pbuilder_C10foremanlog'),
+  }
+
+  file { "/etc/pbuilder/${name}/hooks/F99printrepos":
+    ensure  => $ensure,
+    mode    => '0775',
+    content => file('slave/pbuilder_F99printrepos'),
+  }
+
   # the result cache gets huge after a while - trim it to the last ~2 days at 5am
   file { "/etc/cron.d/cleanup-${name}":
     ensure  => bool2str($ensure == present, 'file', 'absent'),


### PR DESCRIPTION
These hooks originated from the Jenkins jobs that would build
debian packages and are added here as they are static for
every build.