### PR TITLE
Use trusted.gpg.d over apt-key

### DIFF
--- a/puppet/modules/slave/templates/pbuilder_f70.erb
+++ b/puppet/modules/slave/templates/pbuilder_f70.erb
@@ -8,12 +8,6 @@
 #cd /var/cache/pbuilder/result/
 #/usr/bin/dpkg-scanpackages . /dev/null >> /var/cache/pbuilder/result/Packages
 
-# Update apt
-/usr/bin/apt-get update
-
-# Since Debian/stretch, gnupg is not an apt dependency anymore, leading apt-key add to fail
-apt-get -y install gnupg
-
 <% if @backports == true then -%>
 # Backports
 echo "deb http://backports.debian.org/debian-backports/ <%= @release %>-backports main" >> /etc/apt/sources.list
@@ -24,7 +18,7 @@ echo "deb http://backports.debian.org/debian-backports/ <%= @release %>-backport
 # Nodesource
 echo "deb http://deb.nodesource.com/node_12.x <%= @release %> main" >> /etc/apt/sources.list
 
-cat <<EOF | apt-key add -
+cat > /etc/apt/trusted.gpg.d/nodesource.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
 Comment: GPGTools - https://gpgtools.org
@@ -83,7 +77,7 @@ EOF
 <% if @puppetlabs == true then %>
 echo "deb http://apt.puppet.com <%= @release %> puppet6" >> /etc/apt/sources.list
 
-cat <<EOF | apt-key add -
+cat > /etc/apt/trusted.gpg.d/puppet.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBFe2Iz4BEADqbv/nWmR26bsivTDOLqrfBEvRu9kSfDMzYh9Bmik1A8Z036Eg
@@ -113,9 +107,6 @@ b3uYiId38HYbHmD6rDrOQL/2VPPXbdGbxDGQUgX1DfdOuFXw1hSTilwI1KdXxUXD
 sCsZbchgliqGcI1l2En62+6pI2x5XQqqiJ7+
 =HpaX
 -----END PGP PUBLIC KEY BLOCK-----
-EOF
-
-cat <<EOF | apt-key add -
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBFyrv4oBEADhL8iyDPZ+GWN7L+A8dpEpggglxTtL7qYNyN5Uga2j0cusDdOD
@@ -152,7 +143,7 @@ EOF
 # Get the Foreman GPG key, just in case we've added the repo
 # in an earlier hook (via Jenkins, say). Sadly wget is not available in
 # pbuilder image, so this is a bit hacky...
-cat <<EOF | apt-key add -
+cat > /etc/apt/trusted.gpg.d/foreman.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v2.0.22 (GNU/Linux)
 
@@ -205,9 +196,6 @@ kNo8dY3LUn8NlQJ/qtBZDNf/OvP5LjiHPJdLlTyc+eZDGIszkPwLO/rjUfJGaD20
 1vYLOIp+VREV4ODtMQfkLv7W+ynhzAgOZJBiJWU0CwLbnWza4D+yIIc=
 =Fyc2
 -----END PGP PUBLIC KEY BLOCK-----
-EOF
-
-cat <<EOF | apt-key add -
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGD6Y/UBEADOhGOD74lvHdUAew1cHjAUTbopfoXvFvo5jXs4ra3IblnzPEOJ


### PR DESCRIPTION
This means it's no longer needed to install gnupg which makes it slightly faster.

I should note I didn't test this.