### PR TITLE
don't env-reset jenkins when doing sudo

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -10,7 +10,7 @@ class slave (
 
   # On Debian we use pbuilder with sudo
   $sudo = $facts['os']['family'] ? {
-    'Debian' => 'ALL=NOPASSWD: ALL',
+    'Debian' => "ALL=NOPASSWD: ALL\nDefaults:jenkins env_keep += FOREMAN_VERSION",
     default  => '',
   }
 

--- a/puppet/spec/classes/slave_spec.rb
+++ b/puppet/spec/classes/slave_spec.rb
@@ -13,7 +13,7 @@ describe 'slave' do
         end
         it { is_expected.to compile.with_all_deps }
         if facts[:osfamily] == 'Debian'
-          it { is_expected.to contain_users__account('jenkins').with_sudo('ALL=NOPASSWD: ALL') }
+          it { is_expected.to contain_users__account('jenkins').with_sudo("ALL=NOPASSWD: ALL\nDefaults:jenkins env_keep += FOREMAN_VERSION") }
         else
           it { is_expected.to contain_users__account('jenkins').with_sudo('') }
         end


### PR DESCRIPTION
the way pbuilder works under the hood, it ends up calling sudo inside
the pbuilder run, and drops the env