### PR TITLE
explicitly set buildresult to ..

### DIFF
--- a/puppet/modules/slave/manifests/pbuilder_setup.pp
+++ b/puppet/modules/slave/manifests/pbuilder_setup.pp
@@ -31,7 +31,7 @@ define slave::pbuilder_setup (
   file { "/usr/local/bin/pdebuild-${name}":
     ensure  => $ensure,
     mode    => '0775',
-    content => "#!/bin/bash\n pdebuild --use-pdebuild-internal --configfile /etc/pbuilder/${name}/pbuilderrc --architecture ${arch}\n",
+    content => "#!/bin/bash\n pdebuild --use-pdebuild-internal --configfile /etc/pbuilder/${name}/pbuilderrc --architecture ${arch} --buildresult ..\n",
   }
 
   file { "/etc/pbuilder/${name}/hooks/F60addforemanrepo":

--- a/puppet/modules/slave/manifests/pbuilder_setup.pp
+++ b/puppet/modules/slave/manifests/pbuilder_setup.pp
@@ -31,7 +31,7 @@ define slave::pbuilder_setup (
   file { "/usr/local/bin/pdebuild-${name}":
     ensure  => $ensure,
     mode    => '0775',
-    content => "#!/bin/bash\n pdebuild --use-pdebuild-internal --configfile /etc/pbuilder/${name}/pbuilderrc --architecture ${arch} --buildresult ..\n",
+    content => template('slave/pbuilder_pdebuild.erb'),
   }
 
   file { "/etc/pbuilder/${name}/hooks/F60addforemanrepo":

--- a/puppet/modules/slave/templates/pbuilder_pdebuild.erb
+++ b/puppet/modules/slave/templates/pbuilder_pdebuild.erb
@@ -1,0 +1,2 @@
+#!/bin/bash
+pdebuild --use-pdebuild-internal --configfile /etc/pbuilder/<%= @name %>/pbuilderrc --architecture <%= @arch %> --buildresult ..


### PR DESCRIPTION
pbulder defaults to storing its build results in `/var/cache/pbuilder/result` (and this is also hardcoded in [1]).
however, when using (p)debuild, you end up having your built debs in the directory above the one you started the build in (= `..`).
due to the fact that we explicitly configure `BUILDRESULT` ([2]) in our pbuilderrc, it tries to copy files to `/var/cache/pbuilder/result` too, which now fails as we don't call pdebuild with sudo anymore.

we can explicitly pass `--buildresult ..` to pdebuild, which will result in a warning, as it tries to copy files to a place they are already present, but otherwise this works well.

    I: file ../hello-dbgsym_2.10-2_amd64.deb is already in target, not copying.
    I: file ../hello_2.10-2_amd64.buildinfo is already in target, not copying.
    I: file ../hello_2.10-2_amd64.deb is already in target, not copying.
    I: file ../hello_2.10-2_amd64.changes is already in target, not copying.

[1] https://github.com/voxpupuli/puppet-pbuilder/blob/2ba75ff85ddabadf1532ea93991bbd1f58f24df9/manifests/init.pp#L65
[2] https://github.com/voxpupuli/puppet-pbuilder/blob/2ba75ff85ddabadf1532ea93991bbd1f58f24df9/templates/pbuilderrc.erb#L25