### PR TITLE
Run puppet generate deploy in deploy-puppet

### DIFF
--- a/puppet/modules/deploy/files/script.sh
+++ b/puppet/modules/deploy/files/script.sh
@@ -2,8 +2,10 @@
 set -e # dont rsync if clone fails
 echo "Deploy started at `date`"
 dir=`mktemp -d`
+environment=production
 trap "rm -rf ${dir}" EXIT
 git clone --recurse-submodules https://github.com/theforeman/foreman-infra ${dir}/
 g10k -quiet -puppetfile -puppetfilelocation ${dir}/puppet/Puppetfile_forge -moduledir ${dir}/puppet/forge_modules
-rsync -aqx --delete-after --exclude=.git ${dir}/puppet/* /etc/puppetlabs/code/environments/production/
+rsync -aqx --delete-after --exclude=.git ${dir}/puppet/* /etc/puppetlabs/code/environments/$enviroment/
+puppet generate types --environment $enviroment
 echo "Deploy complete at `date`"


### PR DESCRIPTION
This creates a .resource_types directory which is needed by Puppetserver to have proper environment isolation. It also helps with changing type signatures like the addition of a parameter.