### PR TITLE
[deploy] Force production config location & speed up clone

### DIFF
--- a/puppet/modules/deploy/files/script.sh
+++ b/puppet/modules/deploy/files/script.sh
@@ -4,7 +4,7 @@ echo "Deploy started at `date`"
 dir=`mktemp -d`
 environment=production
 trap "rm -rf ${dir}" EXIT
-git clone https://github.com/theforeman/foreman-infra ${dir}/
+git clone --quiet --depth 1 https://github.com/theforeman/foreman-infra ${dir}/
 g10k -quiet -puppetfile -puppetfilelocation ${dir}/puppet/Puppetfile -moduledir ${dir}/puppet/external_modules
 rsync -aqx --delete-after --exclude=.git ${dir}/puppet/* /etc/puppetlabs/code/environments/$environment/
 puppet generate types --environment $environment --config /etc/puppetlabs/puppet/puppet.conf

--- a/puppet/modules/deploy/files/script.sh
+++ b/puppet/modules/deploy/files/script.sh
@@ -7,5 +7,5 @@ trap "rm -rf ${dir}" EXIT
 git clone https://github.com/theforeman/foreman-infra ${dir}/
 g10k -quiet -puppetfile -puppetfilelocation ${dir}/puppet/Puppetfile -moduledir ${dir}/puppet/external_modules
 rsync -aqx --delete-after --exclude=.git ${dir}/puppet/* /etc/puppetlabs/code/environments/$environment/
-puppet generate types --environment $environment
+puppet generate types --environment $environment --config /etc/puppetlabs/puppet/puppet.conf
 echo "Deploy complete at `date`"


### PR DESCRIPTION
When puppet runs as non-root, it uses ~/.puppetlabs and the type generation command gets confused:

```console
$ puppet generate types --environment production
Error: no implicit conversion of nil into String
Error: Try 'puppet help generate types' for usage
```

By forcing the root config, it works.

It also speeds up the clone by doing --depth 1 and quiets it.