### PR TITLE
Ensure root SSH config provisions correctly

### DIFF
--- a/puppet/modules/ssh/manifests/init.pp
+++ b/puppet/modules/ssh/manifests/init.pp
@@ -1,8 +1,4 @@
 class ssh {
-  file { '/root/.ssh/authorized_keys':
-    ensure => file,
-  }
-
   $ssh_service = $facts['os']['family'] ? {
     'RedHat' => 'sshd',
     default  => 'ssh',


### PR DESCRIPTION
On a fresh installation the ssh module fails because /root/.ssh doesn't exist and then authorized_keys can't be created. We actually don't need this to be a file at all so we can stop managing it. If we would manage SSH keys, the ssh_authorized_key resource type can create it if needed.