### PR TITLE
Remove kkoji alias

### DIFF
--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -25,10 +25,7 @@ class slave::packaging::rpm (
   }
 
   file { "${homedir}/bin/kkoji":
-    ensure => link,
-    owner  => 'jenkins',
-    group  => 'jenkins',
-    target => '/usr/bin/koji',
+    ensure => absent,
   }
 
   file { "${homedir}/.koji":


### PR DESCRIPTION
Since 9cf09d3335079073b9cb45cf342dcf4273a3583b this alias is unused. This is the first step to cleaning it up (#520).