### PR TITLE
fail if comps.xml can't be fetched

### DIFF
--- a/koji/collection-mash-split.py
+++ b/koji/collection-mash-split.py
@@ -83,11 +83,13 @@ class MashSplit(object):
             clone_cmd = "git clone %s %s" % (gitloc, workdir)
             kobo.shortcuts.run(clone_cmd, workdir="/mnt/tmp/gitrepo/", can_fail=True)
         final_fn = os.path.join(os.path.realpath(finalloc), filename)
-        cmd = "git pull && git archive remotes/origin/%s %s | tar -C %s -x -f -" % (baseloc, filename, finalloc)
+        cmd = "git fetch && git archive remotes/origin/%s %s | tar -C %s -x -f -" % (baseloc, filename, finalloc)
         self.logger.debug("running %s" % cmd)
         status, output = kobo.shortcuts.run(cmd, workdir=workdir, can_fail=True)
         if status != 0:
-            self.logger.warning("Could not download %s/%s/%s. Using local copy." % (gitloc, baseloc, filename))
+            err_msg = "Could not download %s/%s/%s." % (gitloc, baseloc, filename)
+            self.logger.error(err_msg)
+            raise SystemExit(err_msg)
         if not os.path.exists(final_fn):
             self.logger.error("File %s does not exist." % final_fn)
         return final_fn


### PR DESCRIPTION
if for some reason the comps xml can't be fetched from git, error out
instead of using a stale local copy which can contain a wrong set of
packages

also use `git fetch` over `git pull` to avoid merging problems