### PR TITLE
Add two playbooks to generate modules metadata and then add it to an …

### DIFF
--- a/koji/playbooks/add-module-metadata.yaml
+++ b/koji/playbooks/add-module-metadata.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Run modifyrepo_c to add module metadata
+      command: "modifyrepo_c --mdtype=modules {{ modules_metadata }} {{ repository_path }}/repodata"

--- a/koji/playbooks/make-modules-metadata.yaml
+++ b/koji/playbooks/make-modules-metadata.yaml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Collect RPM names
+      # The epoch number in the NEVRA string is mandatory per spec
+      # https://github.com/fedora-modularity/libmodulemd/blob/main/yaml_specs/modulemd_stream_v2.yaml#L668
+      # So we can't just use `%{nevra}` here
+      command: "rpm --query --package {{ repository_path }}/*rpm --queryformat='%{name}-%{epochnum}:%{version}-%{release}.%{arch}\n'"
+      register: rpm_names
+
+    - name: Split RPM names into list
+      set_fact:
+        rpm_list: "{{ rpm_names.stdout_lines }}"
+
+    - name: Read base modules file
+      set_fact:
+        modules: "{{ lookup('file', modules_base) | from_yaml }}"
+
+    - name: Get current date for metadata version
+      set_fact:
+        version: "{{ lookup('pipe', 'date --universal +%Y%m%d%H%M%S') }}"
+
+    - name: Add RPM list to modules
+      set_fact:
+        modules: "{{ modules | combine({'data': {'artifacts': {'rpms': rpm_list}, 'version': (version|int)}}, recursive=True) }}"
+
+    - name: Write modules.yaml
+      copy:
+        dest: "{{ modules_output_path }}/modules.yaml"
+        content: "{{ modules | to_nice_yaml }}"


### PR DESCRIPTION
…existing repository

Module metadata needs to include the set of RPMs with full NEVRA
to allow dependency resolution. This assumes a base modules metadata
file and then analyzes a mashed repository to find all RPMs to add
dynamically to the metadata. The metadata is then added to the repository
via modifyrepo_c.

The workflow change would be:

 1) Run mash like normal
 2) Run make module metadata
 3) Run add module metadata