### PR TITLE
Drop bin/kkoji file definition

### DIFF
--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -24,10 +24,6 @@ class slave::packaging::rpm (
     group  => 'jenkins',
   }
 
-  file { "${homedir}/bin/kkoji":
-    ensure => absent,
-  }
-
   file { "${homedir}/.koji":
     ensure => directory,
     owner  => 'jenkins',


### PR DESCRIPTION
Since 70479ed5b2cec0e653321d4dcda564cdc4061eb7 this is ensured absent. By now it has propagated to all machines and can be dropped.

Fixes #520