### PR TITLE
Correct Vagrant provisioning override

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant.configure("2") do |config|
     override.vm.provider "libvirt" do |libvirt|
       libvirt.memory = "4096"
     end
-    config.vm.provision "install puppet", type: "shell", inline: <<-SHELL
+    override.vm.provision "install puppet", type: "shell", inline: <<-SHELL
       . /etc/os-release
       wget https://apt.puppet.com/puppet6-release-${VERSION_CODENAME}.deb
       apt-get install -y ./puppet6-release-${VERSION_CODENAME}.deb
@@ -73,7 +73,7 @@ Vagrant.configure("2") do |config|
     override.vm.provider "libvirt" do |libvirt|
       libvirt.memory = "4096"
     end
-    config.vm.provision "install puppet", type: "shell", inline: <<-SHELL
+    override.vm.provision "install puppet", type: "shell", inline: <<-SHELL
       . /etc/os-release
       wget https://apt.puppet.com/puppet6-release-${VERSION_CODENAME}.deb
       apt-get install -y ./puppet6-release-${VERSION_CODENAME}.deb


### PR DESCRIPTION
Without this it tries to run the apt code on all boxes instead of only those particular builders.

Fixes: 5d8a9fe524abf3e5ebb96c951ba7f7fe8aa93705
Fixes: 387719b19ea050b3b7925741ca06dd46b780bb61