### PR TITLE
Update (staging)deb.theforeman.org HEADER.html

### DIFF
--- a/puppet/modules/freight/files/deb-HEADER.html
+++ b/puppet/modules/freight/files/deb-HEADER.html
@@ -7,10 +7,12 @@
 <p>Currently we have</p>
 
 <pre>
+deb http://deb.theforeman.org/ bullseye &lt;version&gt;
+deb http://deb.theforeman.org/ bullseye nightly
 deb http://deb.theforeman.org/ buster &lt;version&gt;
-deb http://deb.theforeman.org/ bionic &lt;version&gt;
 deb http://deb.theforeman.org/ buster nightly
-deb http://deb.theforeman.org/ bionic nightly
+deb http://deb.theforeman.org/ focal &lt;version&gt;
+deb http://deb.theforeman.org/ focal nightly
 
 deb http://deb.theforeman.org/ plugins &lt;version&gt;
 deb http://deb.theforeman.org/ plugins nightly
@@ -20,7 +22,16 @@ deb http://deb.theforeman.org/ plugins nightly
 
 <pre>
 wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
-echo "deb http://deb.theforeman.org/ buster nightly" > /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ bullseye nightly" > /etc/apt/sources.list.d/foreman.list
+echo "deb http://deb.theforeman.org/ plugins nightly" >> /etc/apt/sources.list.d/foreman.list
+</pre>
+
+<p>Or dynamically which makes copy-paste easy:</p>
+
+<pre>
+. /etc/os-release
+wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+echo "deb http://deb.theforeman.org/ $VERSION_CODENAME nightly" > /etc/apt/sources.list.d/foreman.list
 echo "deb http://deb.theforeman.org/ plugins nightly" >> /etc/apt/sources.list.d/foreman.list
 </pre>
 

--- a/puppet/modules/freight/files/stagingdeb-HEADER.html
+++ b/puppet/modules/freight/files/stagingdeb-HEADER.html
@@ -3,9 +3,9 @@
 <p>This repo is for building and testing scratch packages before pushing them to the real repos</p>
 
 <p>Every user will have the packages pushed to their own component, based on the github repository used.<br/>
-So if you specified 'ares' as the github repo, and 'buster' as the distro, your package is at:</p>
+So if you specified 'ares' as the github repo, and 'bullseye' as the distro, your package is at:</p>
 
-<pre>deb http://stagingdeb.theforeman.org/ buster ares-nightly</pre>
+<pre>deb http://stagingdeb.theforeman.org/ bullseye ares-nightly</pre>
 
 <p>Plugins are in a similar per-user component:</p>
 


### PR DESCRIPTION
This updates the headers to have the current Debian versions and introduces an easy copy-paste example using /etc/os-release.