### PR TITLE
Revert "add Ubuntu 22.04 Jammy to pbuilder"

### DIFF
--- a/puppet/modules/slave/manifests/packaging/debian.pp
+++ b/puppet/modules/slave/manifests/packaging/debian.pp
@@ -53,12 +53,6 @@ class slave::packaging::debian(
       release    => 'focal',
       apturl     => $ubuntu_mirror,
       aptcontent => "deb ${ubuntu_mirror} focal main restricted universe\ndeb-src ${ubuntu_mirror} focal main restricted universe\n";
-    'jammy64':
-      ensure     => present,
-      arch       => 'amd64',
-      release    => 'jammy',
-      apturl     => $ubuntu_mirror,
-      aptcontent => "deb ${ubuntu_mirror} jammy main restricted universe\ndeb-src ${ubuntu_mirror} jammy main restricted universe\n";
   }
 
   include sudo


### PR DESCRIPTION
This reverts commit 60e38cdcb1a3037afba9d1c2f3f25fd1fe6e4d68.

Jammy uses zstd compression, which dpkg in Debian can't handle: https://bugs.debian.org/892664
This means we cannot bootstrap a Jammy chroot on our Debian-based build infrastructure.