### PR TITLE
don't fail if there is no moduledata to remove

### DIFF
--- a/puppet/modules/web/files/deploy-yumrepo.sh
+++ b/puppet/modules/web/files/deploy-yumrepo.sh
@@ -51,7 +51,7 @@ do_rsync() {
 				if [[ $HAS_MODULES_YAML == yes ]]; then
 					zcat repodata/*-modules.yaml.gz > modules.yaml
 					modifyrepo_c --remove modules repodata/
-					rm repodata/*-modules.yaml.gz
+					rm -f repodata/*-modules.yaml.gz
 				fi
 
 				createrepo_c --skip-symlinks --update .


### PR DESCRIPTION
when merging a fresh repo, there is only one modules.yaml.gz present
and that already gets removed by modifyrepo_c in the previous step.