### PR TITLE
Remove Ruby 2.6 RVM config

### DIFF
--- a/puppet/modules/slave/manifests/rvm.pp
+++ b/puppet/modules/slave/manifests/rvm.pp
@@ -29,6 +29,7 @@ class slave::rvm {
       version => 'ruby-2.5.1',
     }
     slave::rvm_config { 'ruby-2.6':
+      ensure  => absent,
       version => 'ruby-2.6.3',
     }
     slave::rvm_config { 'ruby-2.7':

--- a/puppet/modules/slave/manifests/rvm_config.pp
+++ b/puppet/modules/slave/manifests/rvm_config.pp
@@ -1,21 +1,29 @@
 # @api private
 define slave::rvm_config (
   String[1] $version,
+  Enum['present', 'absent'] $ensure = 'present',
   String[1] $rubygems_version = '3.0.6',
 ) {
   $alias = $title
 
   rvm_system_ruby { $version:
-    ensure => present,
-  } ->
+    ensure => $ensure,
+  }
+
   rvm_alias { $alias:
-    ensure      => present,
+    ensure      => $ensure,
     target_ruby => $version,
-  } ->
-  exec { "${version}/update_rubygems":
-    command  => "rvm ${version} rubygems ${rubygems_version} --force",
-    unless   => "test `rvm ${version} do gem -v` = ${rubygems_version}",
-    path     => '/usr/local/rvm/bin:/usr/bin:/bin',
-    provider => 'shell',
+  }
+
+  if $ensure == 'present' {
+    Rvm_system_ruby[$version] -> Rvm_alias[$alias]
+    -> exec { "${version}/update_rubygems":
+      command  => "rvm ${version} rubygems ${rubygems_version} --force",
+      unless   => "test `rvm ${version} do gem -v` = ${rubygems_version}",
+      path     => '/usr/local/rvm/bin:/usr/bin:/bin',
+      provider => 'shell',
+    }
+  } else {
+    Rvm_alias[$alias] -> Rvm_system_ruby[$version]
   }
 }

--- a/puppet/modules/slave/manifests/rvm_config.pp
+++ b/puppet/modules/slave/manifests/rvm_config.pp
@@ -1,5 +1,8 @@
 # @api private
-define slave::rvm_config($version, $rubygems_version = '3.0.6') {
+define slave::rvm_config (
+  String[1] $version,
+  String[1] $rubygems_version = '3.0.6',
+) {
   $alias = $title
 
   rvm_system_ruby { $version:


### PR DESCRIPTION
No job uses this anymore. The Ruby 2.4 config is still used by Kafo.

For now this is untested, but submitting this while I test it out.