### PR TITLE
Use CentOS Stream 8 for Vagrant jenkins-node-el8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "jenkins-node-el8" do |override|
     override.vm.hostname = "jenkins-node-el8"
-    override.vm.box = "centos/8"
+    override.vm.box = "centos/stream8"
 
     override.vm.provider "libvirt" do |libvirt|
       libvirt.memory = "4096"


### PR DESCRIPTION
CentOS Linux 8 is EOL and no longer installable.