### PR TITLE
update fastly shielding to IAD datacenter

### DIFF
--- a/ansible/fastly.yml
+++ b/ansible/fastly.yml
@@ -16,7 +16,7 @@
           - name: web01.osuosl.theforeman.org
             address: web01.osuosl.theforeman.org
             port: 443
-            shield: bwi-va-us
+            shield: iad-va-us
             ssl_cert_hostname: "{{ item }}.theforeman.org"
             healthcheck: HEADER.html
         conditions:


### PR DESCRIPTION
the BWI one does not offer shielding anymore. this change was
automatically performed on our account by Fastly, just updating our
config to match.

See https://status.fastly.com/incidents/ysgcxswp5h8l for details.