### PR TITLE
Update Java to 11 on Jenkins nodes

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -6,7 +6,10 @@ class slave (
   Boolean $unittests = $facts['os']['family'] == 'RedHat',
   Boolean $packaging = true,
 ) {
-  include java
+  $java_package = if $facts['os']['family'] == 'RedHat' { 'java-11-openjdk-headless' } else { undef }
+  class { 'java':
+    package => $java_package,
+  }
 
   include git
 


### PR DESCRIPTION
Jenkins 2.361.1 has started to require Java 11. On Debian this is already the default, but the puppetlabs-java module defaults to OpenJDK 1.8.0 on EL.