### PR TITLE
Remove Java 1.8 on Jenkins nodes

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -6,7 +6,17 @@ class slave (
   Boolean $unittests = $facts['os']['family'] == 'RedHat',
   Boolean $packaging = true,
 ) {
-  $java_package = if $facts['os']['family'] == 'RedHat' { 'java-11-openjdk-headless' } else { undef }
+
+  if $facts['os']['family'] == 'RedHat' {
+    $java_package = 'java-11-openjdk-headless'
+
+    package { 'java-1.8.0-openjdk-headless':
+      ensure => absent,
+    }
+  } else {
+    $java_package = undef
+  }
+
   class { 'java':
     package => $java_package,
   }


### PR DESCRIPTION
Jenkins should use Java 11, so 1.8 is no longer needed. Having it installed may mean it's used accidentally.

Fixes: 2cdc68e4c86cac88cb350d776ff52df4547e4c7c