### PR TITLE
Remove all Java 1.8 packages from Jenkins nodes

### DIFF
--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -10,9 +10,10 @@ class slave (
   if $facts['os']['family'] == 'RedHat' {
     $java_package = 'java-11-openjdk-headless'
 
-    package { 'java-1.8.0-openjdk-headless':
+    package { ['java-1.8.0-openjdk', 'java-1.8.0-openjdk-headless', 'java-1.8.0-openjdk-devel']:
       ensure => absent,
     }
+    Package['java-1.8.0-openjdk-devel'] -> Package['java-1.8.0-openjdk'] -> Package['java-1.8.0-openjdk-headless']
   } else {
     $java_package = undef
   }


### PR DESCRIPTION
Puppet uses rpm -e to remove packages rather than yum, so removing the leaf package doesn't work since it's still needed by others. This lists all java packages that need to be removed.

Fixes: 7e3425cfb7d6193d32ab0f32ed311c150155ed7a