### PR TITLE
Revert "add Ubuntu 22.04 Jammy to pbuilder"

### DIFF
--- a/puppet/modules/slave/manifests/packaging/debian.pp
+++ b/puppet/modules/slave/manifests/packaging/debian.pp
@@ -55,12 +55,6 @@ class slave::packaging::debian(
       release    => 'focal',
       apturl     => $ubuntu_mirror,
       aptcontent => "deb ${ubuntu_mirror} focal main restricted universe\ndeb-src ${ubuntu_mirror} focal main restricted universe\n";
-    'jammy64':
-      ensure     => present,
-      arch       => 'amd64',
-      release    => 'jammy',
-      apturl     => $ubuntu_mirror,
-      aptcontent => "deb ${ubuntu_mirror} jammy main restricted universe\ndeb-src ${ubuntu_mirror} jammy main restricted universe\n";
   }
 
   include sudo


### PR DESCRIPTION
Our Debian builder is Debian 10 where debootstrap is too old to understand jammy. Only Debian 11's backports knows jammy.

This reverts commit 60e38cdcb1a3037afba9d1c2f3f25fd1fe6e4d68.