### PR TITLE
Update mash Pulpcore 3.21

### DIFF
--- a/koji/collection-mash-split.py
+++ b/koji/collection-mash-split.py
@@ -467,13 +467,14 @@ def main():
             modulemd_suffix = None
 
         mashes = [
-            MashConfig(collection, version, 'el7', 'el7', 'el7'),
             MashConfig(collection, version, 'el8', 'el8', 'el8', modulemd_suffix=modulemd_suffix, modulemd_version=modulemd_version, modulemd_context=modulemd_context)
         ]
 
         if LooseVersion(version) >= LooseVersion("3.18"):
             mashes.append(MashConfig(collection, version, 'el9', 'el9', 'el9'))
 
+        if LooseVersion(version) <= LooseVersion("3.18"):
+            mashes.append(MashConfig(collection, version, 'el7', 'el7', 'el7'))
 
     else:
         raise SystemExit("Unknown collection {}".format(collection))


### PR DESCRIPTION
Making sure that EL9 is added for >= 3.18, and EL7 is only added for release <= 3.18