### PR TITLE
Remove deprecated coding styles

### DIFF
--- a/puppet/modules/secure_ssh/manifests/receiver.pp
+++ b/puppet/modules/secure_ssh/manifests/receiver.pp
@@ -2,16 +2,9 @@
 # permit upload from, the IPs to allow upload from, and
 # the script to run when accepting an upload
 #
-# === Parameters:
-#
-# $keys  Hash of names of keys to permit access from
-#        type:hash
-#
+# @param keys  Hash of names of keys to permit access from
 class secure_ssh::receiver (
-  $keys = {}
+  Hash[String[1], Hash[String[1], Any]] $keys = {},
 ) {
-
-  validate_hash($keys)
-  create_resources(secure_ssh::receiver_setup,$keys)
-
+  create_resources('secure_ssh::receiver_setup', $keys)
 }

--- a/puppet/modules/secure_ssh/manifests/rsync/receiver.pp
+++ b/puppet/modules/secure_ssh/manifests/rsync/receiver.pp
@@ -2,16 +2,9 @@
 # permit upload from, the IPs to allow upload from, and
 # the script to run when accepting an upload
 #
-# === Parameters:
-#
-# $keys  Hash of names of keys to permit access from
-#        type:hash
-#
+# @param keys Hash of names of keys to permit access from
 class secure_ssh::rsync::receiver (
-  $keys = {}
+  Hash[String[1], Hash[String[1], Any]] $keys = {},
 ) {
-
-  validate_hash($keys)
-  create_resources(secure_ssh::rsync::receiver_setup,$keys)
-
+  create_resources('secure_ssh::rsync::receiver_setup', $keys)
 }

--- a/puppet/modules/secure_ssh/manifests/rsync/uploader.pp
+++ b/puppet/modules/secure_ssh/manifests/rsync/uploader.pp
@@ -2,16 +2,9 @@
 # create on a host which will be uploading to hosts configured
 # using the receiver class
 #
-# === Parameters:
-#
-# $keys  Hash of names to user/dir pairs for ssh keys to create
-#        type:hash
-#
+# @param keys Hash of names to user/dir pairs for ssh keys to create
 class secure_ssh::rsync::uploader (
-  $keys = {}
+  Hash[String[1], Hash[String[1], Any]] $keys = {},
 ) {
-
-  validate_hash($keys)
-  create_resources(secure_ssh::rsync::uploader_key,$keys)
-
+  create_resources('secure_ssh::rsync::uploader_key', $keys)
 }

--- a/puppet/modules/secure_ssh/manifests/uploader.pp
+++ b/puppet/modules/secure_ssh/manifests/uploader.pp
@@ -2,16 +2,10 @@
 # create on a host which will be uploading to hosts configured
 # using the receiver class
 #
-# === Parameters:
-#
-# $keys  Hash of names to user/dir pairs for ssh keys to create
-#        type:hash
-#
+# @param keys
+#   Hash of names to user/dir pairs for ssh keys to create
 class secure_ssh::uploader (
-  $keys = {}
+  Hash[String[1], Hash[String[1], Any]] $keys = {},
 ) {
-
-  validate_hash($keys)
-  create_resources(secure_ssh::uploader_key,$keys)
-
+  create_resources('secure_ssh::uploader_key', $keys)
 }


### PR DESCRIPTION
`validate_hash` is deprecated in favor of native data types. Also uses puppet-strings documentation.