### PR TITLE
Generate SSH keys in Puppet's vardir

### DIFF
--- a/puppet/modules/profiles/manifests/web.pp
+++ b/puppet/modules/profiles/manifests/web.pp
@@ -17,16 +17,12 @@
 # @param rsync_max_connections
 #   Maximum connection per rsync target. Using a small value to try and reduce
 #   server load
-#
-# @param setup_receiver
-#   Set up the SSH receiver setup. Mostly turned off for testing.
 class profiles::web (
   String[1] $stable = '3.4',
   String[1] $next = '3.5',
   Hash[String, Hash] $debugs_htpasswds = {},
   Boolean $https = true,
   Integer[0] $rsync_max_connections = 10,
-  Boolean $setup_receiver = true,
 ) {
   contain awstats
 
@@ -37,14 +33,8 @@ class profiles::web (
   }
   contain web
 
-  class { 'web::vhost::archivedeb':
-    setup_receiver => $setup_receiver,
-  }
   contain web::vhost::archivedeb
 
-  class { 'web::vhost::deb':
-    setup_receiver => $setup_receiver,
-  }
   contain web::vhost::deb
 
   class { 'web::vhost::debugs':
@@ -54,26 +44,20 @@ class profiles::web (
 
   class { 'web::vhost::downloads':
     rsync_max_connections => $rsync_max_connections,
-    setup_receiver        => $setup_receiver,
   }
   contain web::vhost::downloads
 
-  class { 'web::vhost::stagingdeb':
-    setup_receiver => $setup_receiver,
-  }
   contain web::vhost::stagingdeb
 
   class { 'web::vhost::web':
-    stable         => $stable,
-    next           => $next,
-    setup_receiver => $setup_receiver,
+    stable => $stable,
+    next   => $next,
   }
   contain web::vhost::web
 
   class { 'web::vhost::yum':
     stable                => $stable,
     rsync_max_connections => $rsync_max_connections,
-    setup_receiver        => $setup_receiver,
   }
   contain web::vhost::yum
 }

--- a/puppet/modules/ssh/lib/puppet/parser/functions/ssh_keygen.rb
+++ b/puppet/modules/ssh/lib/puppet/parser/functions/ssh_keygen.rb
@@ -5,7 +5,7 @@
 #     :name   (the name of the key - e.g 'my_ssh_key')
 #   Optional parameters:
 #     :type   (the key type - default: 'rsa')
-#     :dir    (the subdir of /etc/puppet/ to store the key in - default: 'ssh')
+#     :dir    (the subdir of Puppet's vardir to store the key in - default: 'ssh')
 #     :size   (the key size - default 2048)
 #     :public (if specified, reads the public key instead of the private key)
 #
@@ -30,8 +30,7 @@ module Puppet::Parser::Functions
     # Ensure ecdsa uses keylength 521
     config['size'] = 521  if config['type'] == 'ecdsa'
 
-    # XXX hard coded path!
-    fullpath = "/etc/puppet/#{config['dir']}"
+    fullpath = File.join(Puppet[:vardir], config['dir'])
 
     # Make sure to write out a directory to init if necessary
     begin

--- a/puppet/modules/web/manifests/vhost/archivedeb.pp
+++ b/puppet/modules/web/manifests/vhost/archivedeb.pp
@@ -3,7 +3,6 @@
 class web::vhost::archivedeb(
   String $user = 'freightarchive',
   Stdlib::Absolutepath $home = "/home/${user}",
-  Boolean $setup_receiver = true,
 ) {
   # Manual step: each user needs the GPG key in it's keyring
   freight::user { 'archive':
@@ -15,13 +14,11 @@ class web::vhost::archivedeb(
     cron_matches => [],
   }
 
-  if $setup_receiver {
-    secure_ssh::rsync::receiver_setup { $user:
-      user           => $user,
-      homedir        => $home,
-      homedir_mode   => '0750',
-      foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
-      script_content => template('freight/rsync.erb'),
-    }
+  secure_ssh::rsync::receiver_setup { $user:
+    user           => $user,
+    homedir        => $home,
+    homedir_mode   => '0750',
+    foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
+    script_content => template('freight/rsync.erb'),
   }
 }

--- a/puppet/modules/web/manifests/vhost/deb.pp
+++ b/puppet/modules/web/manifests/vhost/deb.pp
@@ -3,7 +3,6 @@
 class web::vhost::deb (
   String $user = 'freight',
   Stdlib::Absolutepath $home = "/home/${user}",
-  Boolean $setup_receiver = true,
 ) {
   # Manual step: each user needs the GPG key in it's keyring
   freight::user { 'main':
@@ -15,29 +14,27 @@ class web::vhost::deb (
     cron_matches => ['nightly', 'scratch'],
   }
 
-  if $setup_receiver {
-    # Can't use a standard rsync define here as we need to extend the
-    # script to handle deployment too
-    secure_ssh::receiver_setup { $user:
-      user           => $user,
-      groups         => ['freightstage'],
-      homedir        => $home,
-      foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
-      script_content => template('freight/rsync_main.erb'),
-      ssh_key_name   => "rsync_${user}_key",
-    }
-    file { "${home}/rsync_cache":
-      ensure => directory,
-      owner  => $user,
-    }
-    # This ruby script is called from the secure_freight template
-    file { "${home}/bin/secure_deploy_debs":
-      ensure  => file,
-      owner   => 'freight',
-      mode    => '0700',
-      content => template('freight/deploy_debs.erb'),
-    }
-
-    User <| title == 'freightstage' |> -> User <| title == $user |>
+  # Can't use a standard rsync define here as we need to extend the
+  # script to handle deployment too
+  secure_ssh::receiver_setup { $user:
+    user           => $user,
+    groups         => ['freightstage'],
+    homedir        => $home,
+    foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
+    script_content => template('freight/rsync_main.erb'),
+    ssh_key_name   => "rsync_${user}_key",
   }
+  file { "${home}/rsync_cache":
+    ensure => directory,
+    owner  => $user,
+  }
+  # This ruby script is called from the secure_freight template
+  file { "${home}/bin/secure_deploy_debs":
+    ensure  => file,
+    owner   => 'freight',
+    mode    => '0700',
+    content => template('freight/deploy_debs.erb'),
+  }
+
+  User <| title == 'freightstage' |> -> User <| title == $user |>
 }

--- a/puppet/modules/web/manifests/vhost/downloads.pp
+++ b/puppet/modules/web/manifests/vhost/downloads.pp
@@ -4,7 +4,6 @@ class web::vhost::downloads (
   Stdlib::Absolutepath $downloads_directory = '/var/www/vhosts/downloads/htdocs',
   Integer[0] $rsync_max_connections = 5,
   String $user = 'downloads',
-  Boolean $setup_receiver = true,
 ) {
   $downloads_directory_config = [
     {
@@ -19,12 +18,10 @@ class web::vhost::downloads (
     },
   ]
 
-  if $setup_receiver {
-    secure_ssh::receiver_setup { $user:
-      user           => $user,
-      foreman_search => 'host ~ node*.jenkins.osuosl.theforeman.org and (name = external_ip4 or name = external_ip6)',
-      script_content => template('web/rsync_downloads.sh.erb'),
-    }
+  secure_ssh::receiver_setup { $user:
+    user           => $user,
+    foreman_search => 'host ~ node*.jenkins.osuosl.theforeman.org and (name = external_ip4 or name = external_ip6)',
+    script_content => template('web/rsync_downloads.sh.erb'),
   }
 
   web::vhost { 'downloads':

--- a/puppet/modules/web/manifests/vhost/stagingdeb.pp
+++ b/puppet/modules/web/manifests/vhost/stagingdeb.pp
@@ -3,7 +3,6 @@
 class web::vhost::stagingdeb(
   String $user = 'freightstage',
   Stdlib::Absolutepath $home = "/home/${user}",
-  Boolean $setup_receiver = true,
 ) {
   # Manual step: each user needs the GPG key in it's keyring
   freight::user { 'staging':
@@ -15,13 +14,11 @@ class web::vhost::stagingdeb(
     cron_matches => 'all',
   }
 
-  if $setup_receiver {
-    secure_ssh::rsync::receiver_setup { $user:
-      user           => $user,
-      homedir        => $home,
-      homedir_mode   => '0750',
-      foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
-      script_content => template('freight/rsync.erb'),
-    }
+  secure_ssh::rsync::receiver_setup { $user:
+    user           => $user,
+    homedir        => $home,
+    homedir_mode   => '0750',
+    foreman_search => 'host.hostgroup = Debian and (name = external_ip4 or name = external_ip6)',
+    script_content => template('freight/rsync.erb'),
   }
 }

--- a/puppet/modules/web/manifests/vhost/web.pp
+++ b/puppet/modules/web/manifests/vhost/web.pp
@@ -3,7 +3,6 @@
 class web::vhost::web(
   String[1] $stable,
   String[1] $next,
-  Boolean $setup_receiver = true,
   Stdlib::Absolutepath $web_directory = '/var/www/vhosts/web/htdocs',
 ) {
   require web
@@ -82,12 +81,10 @@ class web::vhost::web(
     },
   }
 
-  if $setup_receiver {
-    secure_ssh::rsync::receiver_setup { 'web':
-      user           => 'website',
-      foreman_search => 'host ~ node*.jenkins.osuosl.theforeman.org and (name = external_ip4 or name = external_ip6)',
-      script_content => file('web/rsync.sh'),
-    }
+  secure_ssh::rsync::receiver_setup { 'web':
+    user           => 'website',
+    foreman_search => 'host ~ node*.jenkins.osuosl.theforeman.org and (name = external_ip4 or name = external_ip6)',
+    script_content => file('web/rsync.sh'),
   }
 
   # Generate RSS stats

--- a/puppet/modules/web/manifests/vhost/yum.pp
+++ b/puppet/modules/web/manifests/vhost/yum.pp
@@ -6,7 +6,6 @@ class web::vhost::yum (
   Stdlib::Fqdn $servername = 'yum.theforeman.org',
   Stdlib::Absolutepath $yum_directory = '/var/www/vhosts/yum/htdocs',
   String $user = 'yumrepo',
-  Boolean $setup_receiver = true,
 ) {
   $yum_directory_config = [
     {
@@ -29,12 +28,10 @@ class web::vhost::yum (
     },
   ]
 
-  if $setup_receiver {
-    secure_ssh::receiver_setup { $user:
-      user           => $user,
-      foreman_search => 'host ~ node*.jenkins.osuosl.theforeman.org and (name = external_ip4 or name = external_ip6)',
-      script_content => file('web/deploy-yumrepo.sh'),
-    }
+  secure_ssh::receiver_setup { $user:
+    user           => $user,
+    foreman_search => 'host ~ node*.jenkins.osuosl.theforeman.org and (name = external_ip4 or name = external_ip6)',
+    script_content => file('web/deploy-yumrepo.sh'),
   }
 
   web::vhost { 'yum':

--- a/puppet/spec/classes/profiles_web_spec.rb
+++ b/puppet/spec/classes/profiles_web_spec.rb
@@ -4,12 +4,11 @@ describe 'profiles::web' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
-      let(:params) { {setup_receiver: false} }
 
       it { is_expected.to compile.with_all_deps }
 
       context 'without https' do
-        let(:params) { super().merge(https: false) }
+        let(:params) { { https: false } }
 
         it { is_expected.to compile.with_all_deps }
       end


### PR DESCRIPTION
Rather than hardcoding it to /etc/puppet (which doesn't exist on a Puppet AIO install) this uses the vardir setting. This works well for extlib::cache_data. As an additional benefit it can now run this in tests on a non-privileged user.