### PR TITLE
Use the non-deprecated foreman::foreman method

### DIFF
--- a/puppet/modules/secure_ssh/manifests/receiver_setup.pp
+++ b/puppet/modules/secure_ssh/manifests/receiver_setup.pp
@@ -57,12 +57,7 @@ define secure_ssh::receiver_setup (
 
   if $foreman_search and defined('$::foreman_api_user') and defined('$::foreman_api_password') {
     # Get the IPs of the uploaders from foreman
-    $ip_data=foreman({
-        'item'         => 'fact_values',
-        'search'       => $foreman_search,
-        'foreman_user' => $::foreman_api_user,
-        'foreman_pass' => $::foreman_api_password,
-    })
+    $ip_data = foreman::foreman('fact_values', $foreman_search, '20', lookup('foreman_url'), $::foreman_api_user, $::foreman_api_password)
   }
 
   file { "${homedir}/.ssh/authorized_keys":


### PR DESCRIPTION
This now passes in per_page as a string due to https://github.com/theforeman/puppet-foreman/pull/1089