### PR TITLE
Drop Debian 9 & 10 support in our Puppet infra

### DIFF
--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -14,7 +14,7 @@ def on_supported_os(opts = {})
     },
     {
       'operatingsystem'        => 'Debian',
-      'operatingsystemrelease' => ['9', '10', '11'],
+      'operatingsystemrelease' => ['11'],
     },
   ]
   super(opts)


### PR DESCRIPTION
Today we only run Debian 11