### PR TITLE
Add Debian 9 back

### DIFF
--- a/puppet/spec/spec_helper.rb
+++ b/puppet/spec/spec_helper.rb
@@ -14,7 +14,7 @@ def on_supported_os(opts = {})
     },
     {
       'operatingsystem'        => 'Debian',
-      'operatingsystemrelease' => ['11'],
+      'operatingsystemrelease' => ['9', '11'],
     },
   ]
   super(opts)


### PR DESCRIPTION
I forgot Discourse still runs on a Debian 9 install.

Fixes: 1607af1e0fc232a6176691640cbb3387fca4ab04