### PR TITLE
Switch Debian package building to Puppet 7

### DIFF
--- a/puppet/modules/slave/files/pbuilder_F67-add-puppet-repos
+++ b/puppet/modules/slave/files/pbuilder_F67-add-puppet-repos
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "deb http://apt.puppet.com ${DISTRIBUTION} puppet6" >> /etc/apt/sources.list
+echo "deb http://apt.puppet.com ${DISTRIBUTION} puppet7" >> /etc/apt/sources.list
 
 cat > /etc/apt/trusted.gpg.d/puppet.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
We've updated develop to puppet-strings 3.x which requires Ruby 2.7.  Puppet 6 ships Ruby 2.5 while Puppet 7 has 2.7.