### PR TITLE
Mark Foreman 3.6 as the next version

### DIFF
--- a/puppet/modules/profiles/manifests/web.pp
+++ b/puppet/modules/profiles/manifests/web.pp
@@ -19,7 +19,7 @@
 #   server load
 class profiles::web (
   String[1] $stable = '3.4',
-  String[1] $next = '3.5',
+  String[1] $next = '3.6',
   Hash[String, Hash] $debugs_htpasswds = {},
   Boolean $https = true,
   Integer[0] $rsync_max_connections = 10,


### PR DESCRIPTION
This redirects 3.6 to nightly, which will be the next Foreman version once we branch.