### PR TITLE
Update Rubygems to 3.1.6 for Ruby 2.7

### DIFF
--- a/puppet/modules/slave/manifests/rvm.pp
+++ b/puppet/modules/slave/manifests/rvm.pp
@@ -34,7 +34,7 @@ class slave::rvm {
     }
     slave::rvm_config { 'ruby-2.7':
       version          => 'ruby-2.7.4',
-      rubygems_version => '3.1.2',
+      rubygems_version => '3.1.6',
     }
     slave::rvm_config { 'ruby-3.0':
       version          => 'ruby-3.0.4',


### PR DESCRIPTION
Ruby 2.7.4 bundles 3.1.6. In CI we're seeing issues with Gem::NameTuple and 3.1.3 does have a minor enhancement that may solve it:

> Resolver: require NameTuple before use

It's unclear why we didn't see these failures before.