### PR TITLE
Use chrony on EL7 too

### DIFF
--- a/puppet/modules/profiles/manifests/base.pp
+++ b/puppet/modules/profiles/manifests/base.pp
@@ -6,7 +6,11 @@ class profiles::base (
   include ssh
   include timezone
   include unattended
-  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '8') >= 0 {
+  if $facts['os']['family'] == 'RedHat' {
+    package { 'ntp':
+      ensure => absent,
+      before => Class['chrony'],
+    }
     include chrony
   } else {
     include ntp


### PR DESCRIPTION
Previously we ran chrony on EL7, but the bulk of the hosts didn't use this base profile yet so it wasn't noticed. After the migration this started to show up.

Because it ran on some hosts, this also includes code to remove ntp from the system.

Fixes: e519403be6959247ab8632599dfc1edaa51c2e90