### PR TITLE
Switch the Puppet runmode to systemd.timer

### DIFF
--- a/puppet/data/common.yaml
+++ b/puppet/data/common.yaml
@@ -14,7 +14,7 @@ foreman_proxy::trusted_hosts:
   - "foreman01.conova.theforeman.org"
 foreman_proxy::foreman_base_url: '%{alias("foreman_url")}'
 
-puppet::runmode: cron
+puppet::runmode: systemd.timer
 puppet::puppetmaster: '%{alias("puppet_servicename")}'
 puppet::server_additional_settings:
   dns_alt_names:


### PR DESCRIPTION
Right now Puppet emails for every run:

```
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:91: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:102: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:91: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:102: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:91: warning: URI.escape is obsolete
/opt/puppetlabs/puppet/cache/lib/puppet/type/gnupg_key.rb:102: warning: URI.escape is obsolete
```

While that should be resolved properly, using the systemd timer should avoid a bunch of emails.

Currently testing this out.