### PR TITLE
Match deb-node01 in site.pp

### DIFF
--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -17,7 +17,7 @@ node /^foreman\d+\.[a-z]+\.theforeman\.org$/ {
   include profiles::foreman
 }
 
-node /^node\d+\.jenkins\.[a-z]+\.theforeman\.org$/ {
+node /^(deb-)?node\d+\.jenkins\.[a-z]+\.theforeman\.org$/ {
   include profiles::base
   include profiles::jenkins::node
 }


### PR DESCRIPTION
Previously it was assumed all nodes have nodeXX but we also have deb-nodeXX.

Fixes: 6cbe2656dd605d22475cc4dcdf5fc3f84d0d3072