### PR TITLE
Include backup configuration

### DIFF
--- a/puppet/data/common.yaml
+++ b/puppet/data/common.yaml
@@ -26,3 +26,27 @@ puppet::server_puppetserver_telemetry: false
 puppet::show_diff: true
 
 sudo::wheel_config: password
+
+dirvish::vaults:
+  ci-jenkins:
+    client: master02.rackspace.theforeman.org
+    tree: "/var/lib/jenkins/"
+    expire_default: "+7 days"
+    expire_rules:
+    - "wd { sun } +1 month"
+    excludes:
+    - "/jobs/"
+  redmine:
+    client: "redmine01.theforeman.org"
+    tree: "/var/lib/redmine"
+    expire_default: "+7 days"
+    expire_rules:
+    - "wd { sun } +1 month"
+    excludes:
+    - "/git/"
+  discourse:
+    client: "discourse01.theforeman.org"
+    tree: "/var/lib/discourse"
+    expire_default: "+7 days"
+    expire_rules:
+    - "wd { sun } +1 month"

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -5,16 +5,19 @@ node default {
 node /^controller\d+\.[a-z]+\.theforeman\.org$/ {
   include profiles::base
   include profiles::jenkins::controller
+  include dirvish::client
 }
 
 node /^discourse\d+\.[a-z]+\.theforeman\.org$/ {
   include profiles::base
   # TODO profiles::discourse
+  include dirvish::client
 }
 
 node /^foreman\d+\.[a-z]+\.theforeman\.org$/ {
   include profiles::base
   include profiles::foreman
+  # TODO: include dirvish::client
 }
 
 node /^(deb-)?node\d+\.jenkins\.[a-z]+\.theforeman\.org$/ {
@@ -25,6 +28,7 @@ node /^(deb-)?node\d+\.jenkins\.[a-z]+\.theforeman\.org$/ {
 node /^puppet\d+\.[a-z]+\.theforeman\.org$/ {
   include profiles::base
   include profiles::puppetserver
+  include dirvish
 }
 
 node /^redmine\d+\.[a-z]+\.theforeman\.org$/ {


### PR DESCRIPTION
Prior to this we had this information in the Foreman ENC, but now it's included in Hiera. A possibly better solution would be to search for the correct hostnames using a foreman lookup, but since we don't migrate that often this is good enough for now.