### PR TITLE
Make more modules puppet-lint clean with stricter plugins

### DIFF
--- a/puppet/modules/foreman_debug_rsync/manifests/config.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/config.pp
@@ -1,9 +1,10 @@
+# @summary The configuration of the rsync server
+# @api private
 class foreman_debug_rsync::config {
-
   include 'rsync'
   include 'rsync::server'
 
-  rsync::server::module{ 'debug-incoming':
+  rsync::server::module { 'debug-incoming':
     path            => $foreman_debug_rsync::base,
     require         => File[$foreman_debug_rsync::base],
     comment         => 'Write-only place for foreman-debug',

--- a/puppet/modules/foreman_debug_rsync/manifests/cron.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/cron.pp
@@ -1,4 +1,5 @@
-# Clean out old tarballs
+# @summary Clean out old tarballs
+# @api private
 class foreman_debug_rsync::cron {
   cron { 'remove-old-tarballs':
     command => "/usr/bin/find ${foreman_debug_rsync::base} -type f -mtime +90 -exec rm {} \\;",

--- a/puppet/modules/foreman_debug_rsync/manifests/init.pp
+++ b/puppet/modules/foreman_debug_rsync/manifests/init.pp
@@ -1,8 +1,15 @@
+# @summary Manage the debug rsync setup
+#
+# Users can upload their debugs using foreman-debug.
+# This sets up the receiver part of that.
+#
+# @param base
+#   The base directory where rsync data is stored
 class foreman_debug_rsync (
-  $base = '/var/www/vhosts/debugs/htdocs',
+  Stdlib::Absolutepath $base = '/var/www/vhosts/debugs/htdocs',
 ) {
+  contain foreman_debug_rsync::config
+  contain foreman_debug_rsync::cron
 
-  class { 'foreman_debug_rsync::config': } ->
-  class { 'foreman_debug_rsync::cron': }
-
+  Class['foreman_debug_rsync::config'] -> Class['foreman_debug_rsync::cron']
 }

--- a/puppet/modules/secure_ssh/manifests/rsync/receiver_setup.pp
+++ b/puppet/modules/secure_ssh/manifests/rsync/receiver_setup.pp
@@ -1,4 +1,4 @@
-# Define which deploys the key for a specific user
+# @summary Define which deploys the key for a specific user
 #
 # @param user
 #   User to own the key
@@ -7,8 +7,14 @@
 #   Content of a script that'll be run by sshd when the user connects with the
 #   key
 #
+# @param groups
+#   Groups the user belongs to
+#
 # @param homedir
 #   Home directory the user
+#
+# @param homedir_mode
+#   Mode of the user's home directory
 #
 # @param allowed_ips
 #   List of allowed ips in the authorized keys file. Unused if $foreman_search

--- a/puppet/modules/secure_ssh/manifests/rsync/uploader_key.pp
+++ b/puppet/modules/secure_ssh/manifests/rsync/uploader_key.pp
@@ -1,25 +1,27 @@
-# Define which deploys the key for a specific user
+# @summary Define which deploys the key for a specific user
 #
-# === Parameters:
+# @param name
+#   Name of the key
 #
-# $name:       name of the key (required)
+# @param user
+#   User to own the key
 #
-# $user:       user to own the key (required)
+# @param dir
+#   Directory to store the key in
 #
-# $dir:        directory to store the key in (default: /home/$user/.ssh)
+# @param mode
+#   Mode of $dir
 #
-# $mode:       mode of $dir (default: 0600)
-#
-# $manage_dir  whether or not to manage $dir (default: false)
-#              type: boolean
+# @param manage_dir
+#   Whether or not to manage $dir
 #
 define secure_ssh::rsync::uploader_key (
-  $user,
-  $dir          = "/home/${user}/.ssh",
-  $mode         = '0600',
-  $manage_dir   = false,
+  String[1] $user,
+  Stdlib::Absolutepath $dir = "/home/${user}/.ssh",
+  Stdlib::Filemode $mode = '0600',
+  Boolean $manage_dir = false,
 ) {
-  ::secure_ssh::uploader_key { $name:
+  secure_ssh::uploader_key { $name:
     user         => $user,
     dir          => $dir,
     mode         => $mode,

--- a/puppet/modules/secure_ssh/manifests/uploader_key.pp
+++ b/puppet/modules/secure_ssh/manifests/uploader_key.pp
@@ -1,28 +1,29 @@
 # Define which deploys the key for a specific user
 #
-# === Parameters:
+# @param user
+#   User to own the key
 #
-# $name:       name of the key (required)
+# @param dir
+#   Directory to store the key in
 #
-# $user:       user to own the key (required)
+# @param mode
+#   Mode of $dir
 #
-# $dir:        directory to store the key in (default: /home/$user/.ssh)
+# @param manage_dir
+#   Whether or not to manage $dir
 #
-# $mode:       mode of $dir (default: 0600)
-#
-# $manage_dir  whether or not to manage $dir (default: false)
-#              type: boolean
+# @param ssh_key_name
+#   The name of the key
 #
 define secure_ssh::uploader_key (
-  $user,
-  $dir          = "/home/${user}/.ssh",
-  $mode         = '0600',
-  $manage_dir   = false,
-  $ssh_key_name = "${name}_key",
+  String[1] $user,
+  Stdlib::Absolutepath $dir = "/home/${user}/.ssh",
+  Stdlib::Filemode $mode = '0600',
+  Boolean $manage_dir = false,
+  String[1] $ssh_key_name = "${name}_key",
 ) {
-
-  $pub_key  = ssh_keygen({name => $ssh_key_name, public => 'public'})
-  $priv_key = ssh_keygen({name => $ssh_key_name})
+  $pub_key  = ssh_keygen({ name => $ssh_key_name, public => 'public' })
+  $priv_key = ssh_keygen({ name => $ssh_key_name })
 
   if $manage_dir {
     file { $dir:

--- a/puppet/modules/slave/manifests/init.pp
+++ b/puppet/modules/slave/manifests/init.pp
@@ -1,3 +1,19 @@
+# @summary A Jenkins node
+#
+# @param koji_certificate
+#   The client certificate used to authenticate to Koji. Used for RPM building.
+# @param uploader
+#   Whether the machine can upload Debian packages.
+# @param username
+#   The username to use for running the Jenkins node process
+# @param homedir
+#   The home directory for the user
+# @param workspace
+#   The workspace used by the Jenkins node process
+# @param unittests
+#   Whether the Jenkins node should be able to run Ruby (unit)tests
+# @param packaging
+#   Whether the node should be able to run packaging jobs
 class slave (
   Optional[String] $koji_certificate    = undef,
   Boolean $uploader                     = true,
@@ -7,7 +23,6 @@ class slave (
   Boolean $unittests = $facts['os']['family'] == 'RedHat',
   Boolean $packaging = true,
 ) {
-
   if $facts['os']['family'] == 'RedHat' {
     $java_package = 'java-11-openjdk-headless'
 
@@ -90,14 +105,14 @@ class slave (
   }
 
   if $unittests {
-    class {'slave::unittests':
+    class { 'slave::unittests':
       homedir => $homedir,
     }
   }
 
   # Packaging
   if $packaging {
-    class {'slave::packaging':
+    class { 'slave::packaging':
       koji_certificate => $koji_certificate,
       uploader         => $uploader,
       homedir          => $homedir,

--- a/puppet/modules/slave/manifests/packaging.pp
+++ b/puppet/modules/slave/manifests/packaging.pp
@@ -1,11 +1,10 @@
 # @api private
-class slave::packaging(
+class slave::packaging (
   Boolean $uploader,
   Stdlib::Absolutepath $homedir,
   Stdlib::Absolutepath $workspace,
   Optional[String] $koji_certificate = undef,
 ) {
-
   # CLI JSON parser
   package { 'jq':
     ensure => installed,
@@ -29,5 +28,4 @@ class slave::packaging(
     }
     default: {}
   }
-
 }

--- a/puppet/modules/slave/manifests/pbuilder_setup.pp
+++ b/puppet/modules/slave/manifests/pbuilder_setup.pp
@@ -1,14 +1,15 @@
+# @summary Set up pbuilder on a Debian package builder
+# @api private
 define slave::pbuilder_setup (
-  $arch,
-  $release,
-  $apturl,
-  $aptcontent,
-  $ensure     = present,
+  String[1] $arch,
+  String[1] $release,
+  String[1] $apturl,
+  String[1] $aptcontent,
+  Enum['present', 'absent'] $ensure = present,
   Boolean $backports  = false,
   Boolean $nodesource = true,
   Boolean $puppetlabs = true,
 ) {
-
   pbuilder { $name:
     ensure    => $ensure,
     arch      => $arch,

--- a/puppet/modules/slave/manifests/rvm.pp
+++ b/puppet/modules/slave/manifests/rvm.pp
@@ -16,7 +16,7 @@ class slave::rvm {
   } ->
   Class['Rvm::System']
 
-  if $::rvm_installed == true {
+  if $facts['rvm_installed'] {
     rvm::system_user { 'jenkins':
       create  => false,
       require => User['jenkins'],

--- a/puppet/modules/slave/manifests/swap.pp
+++ b/puppet/modules/slave/manifests/swap.pp
@@ -5,7 +5,7 @@
 #
 # @param size_mb
 #   The size in MBs
-class slave::swap(
+class slave::swap (
   Stdlib::Absolutepath $file = '/swap',
   Integer[0] $size_mb = 2048,
 ) {

--- a/puppet/modules/slave/manifests/unittests.pp
+++ b/puppet/modules/slave/manifests/unittests.pp
@@ -1,5 +1,5 @@
 # @api private
-class slave::unittests(
+class slave::unittests (
   Stdlib::Absolutepath $homedir,
 ) {
   $is_el8 = $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8'


### PR DESCRIPTION
Locally I have voxpupuli-puppet-lint-plugins installed. This causes additional plugins to load. These rules are stricter and our CI doesn't catch these. This prepares the code base to include these.