### PR TITLE
Use user's own cache directory for g10k & shellcheck the script

### DIFF
--- a/puppet/modules/deploy/files/script.sh
+++ b/puppet/modules/deploy/files/script.sh
@@ -5,7 +5,7 @@ dir=$(mktemp -d)
 environment=production
 trap 'rm -rf ${dir}' EXIT
 git clone --quiet --depth 1 https://github.com/theforeman/foreman-infra "${dir}/"
-g10k -quiet -puppetfile -puppetfilelocation "${dir}"/puppet/Puppetfile -moduledir "${dir}/puppet/external_modules"
+g10k -quiet -cachedir "$HOME/.cache/g10k" -puppetfile -puppetfilelocation "${dir}/puppet/Puppetfile" -moduledir "${dir}/puppet/external_modules"
 rsync -aqx --delete-after --exclude=.git "${dir}"/puppet/* "/etc/puppetlabs/code/environments/$environment/"
 puppet generate types --environment "$environment" --config /etc/puppetlabs/puppet/puppet.conf
 echo "Deploy complete at $(date)"

--- a/puppet/modules/deploy/files/script.sh
+++ b/puppet/modules/deploy/files/script.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e # dont rsync if clone fails
-echo "Deploy started at `date`"
-dir=`mktemp -d`
+echo "Deploy started at $(date)"
+dir=$(mktemp -d)
 environment=production
-trap "rm -rf ${dir}" EXIT
-git clone --quiet --depth 1 https://github.com/theforeman/foreman-infra ${dir}/
-g10k -quiet -puppetfile -puppetfilelocation ${dir}/puppet/Puppetfile -moduledir ${dir}/puppet/external_modules
-rsync -aqx --delete-after --exclude=.git ${dir}/puppet/* /etc/puppetlabs/code/environments/$environment/
-puppet generate types --environment $environment --config /etc/puppetlabs/puppet/puppet.conf
-echo "Deploy complete at `date`"
+trap 'rm -rf ${dir}' EXIT
+git clone --quiet --depth 1 https://github.com/theforeman/foreman-infra "${dir}/"
+g10k -quiet -puppetfile -puppetfilelocation "${dir}"/puppet/Puppetfile -moduledir "${dir}/puppet/external_modules"
+rsync -aqx --delete-after --exclude=.git "${dir}"/puppet/* "/etc/puppetlabs/code/environments/$environment/"
+puppet generate types --environment "$environment" --config /etc/puppetlabs/puppet/puppet.conf
+echo "Deploy complete at $(date)"


### PR DESCRIPTION
g10k defaults to /tmp/g10k, which should be considered insecure. This uses one that isn't shared with other users.

Also pleases shellcheck.