### PR TITLE
Get koji_certificate from global variables

### DIFF
--- a/puppet/modules/profiles/manifests/jenkins/node.pp
+++ b/puppet/modules/profiles/manifests/jenkins/node.pp
@@ -13,7 +13,7 @@
 # @param packaging
 #   Should the node be able to run packaging jobs
 class profiles::jenkins::node (
-  Optional[String[1]] $koji_certificate = undef,
+  Optional[String[1]] $koji_certificate = getvar('koji_certificate'),
   Integer[0] $swap_size_mb = 8192,
   Boolean $unittests = $facts['os']['family'] == 'RedHat',
   Boolean $packaging = true,

--- a/puppet/modules/profiles/manifests/jenkins/node.pp
+++ b/puppet/modules/profiles/manifests/jenkins/node.pp
@@ -12,7 +12,7 @@
 #
 # @param packaging
 #   Should the node be able to run packaging jobs
-class profiles::jenkins::node(
+class profiles::jenkins::node (
   Optional[String[1]] $koji_certificate = undef,
   Integer[0] $swap_size_mb = 8192,
   Boolean $unittests = $facts['os']['family'] == 'RedHat',


### PR DESCRIPTION
In the past Foreman's ENC was used, but since 6cbe2656dd605d22475cc4dcdf5fc3f84d0d3072 the koji certificate was no longer set. Since we don't have a secure way to store secret data in Hiera, this uses Foreman's ENC again.