### PR TITLE
Avoid name collision issue with koji_certificate

### DIFF
--- a/puppet/modules/profiles/manifests/jenkins/node.pp
+++ b/puppet/modules/profiles/manifests/jenkins/node.pp
@@ -13,7 +13,7 @@
 # @param packaging
 #   Should the node be able to run packaging jobs
 class profiles::jenkins::node (
-  Optional[String[1]] $koji_certificate = getvar('koji_certificate'),
+  Optional[String[1]] $koji_certificate = getvar('koji_cert'),
   Integer[0] $swap_size_mb = 8192,
   Boolean $unittests = $facts['os']['family'] == 'RedHat',
   Boolean $packaging = true,


### PR DESCRIPTION
This avoids the following error:

    default expression for $koji_certificate tries to illegally access not yet evaluated $koji_certificate

Fixes: ad305563f6b361fee11d43558b65ae920f61e27f