### PR TITLE
Reflect the correct path in jenkins-jobs

### DIFF
--- a/puppet/modules/jenkins_job_builder/templates/jenkins_jobs.ini.erb
+++ b/puppet/modules/jenkins_job_builder/templates/jenkins_jobs.ini.erb
@@ -6,6 +6,6 @@ url=<%= @url %>
 [job_builder]
 ignore_cache=True
 keep_descriptions=False
-include_path=.:/etc/jenkins_jobs/<%= @config_name %>
+include_path=.:/etc/jenkins_jobs/jenkins-jobs/<%= @config_name %>
 recursive=True
 allow_duplicates=False

--- a/puppet/modules/jenkins_master/manifests/init.pp
+++ b/puppet/modules/jenkins_master/manifests/init.pp
@@ -1,3 +1,4 @@
+# @summary The jenkins controller profile
 class jenkins_master {
   # Devel is needed for jar unpacking support
   $packages = ['java-11-openjdk-headless', 'java-11-openjdk-devel', 'fontconfig']
@@ -183,5 +184,4 @@ class jenkins_master {
     },
     require         => Package[$packages],
   }
-
 }


### PR DESCRIPTION
In b1b5188f3d9d5c037c44ae37a140066f9348e6b7 the directory layout was changed, but the config looked at the old path. This meant that it started to fail when we renamed some files.

Also makes jenkins_master puppet-lint clean, since I opened that file and my editor started to yell at me.