### PR TITLE
Sync Hiera in Vagrant & move node config to it

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ CENTOS_8_BOX_URL = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentO
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
   config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder "puppet/data", "/tmp/vagrant-puppet/data", type: "rsync"
 
   config.vm.provision "install puppet", type: "shell", inline: <<-SHELL
     . /etc/os-release
@@ -15,9 +16,11 @@ Vagrant.configure("2") do |config|
   SHELL
 
   config.vm.provision "run puppet", type: 'puppet' do |puppet|
+    puppet.hiera_config_path = 'vagrant/hiera.yaml'
     puppet.module_path = ["puppet/modules", "puppet/external_modules"]
     puppet.manifests_path = "vagrant/manifests"
     puppet.synced_folder_type = "rsync"
+    puppet.working_directory = "/tmp/vagrant-puppet"
   end
 
   config.vm.define "jenkins-master" do |override|

--- a/puppet/data/vagrant.yaml
+++ b/puppet/data/vagrant.yaml
@@ -1,2 +1,16 @@
 ---
 restic::password: "SomethingVerySecret"
+
+profiles::backup::receiver:
+  - redmine
+  - jenkins-master
+
+profiles::jenkins::controller::hostname: "%{facts.networking.fqdn}"
+profiles::jenkins::controller::https: false
+profiles::jenkins::controller::jenkins_job_builder: true
+profiles::jenkins::controller::jenkins_job_builder_password: "changeme"
+profiles::jenkins::controller::jenkins_job_builder_username: "admin"
+
+profiles::jenkins::node::swap_size_mb: 0
+
+profiles::web::https: false

--- a/puppet/data/vagrant.yaml
+++ b/puppet/data/vagrant.yaml
@@ -1,0 +1,2 @@
+---
+restic::password: "SomethingVerySecret"

--- a/vagrant/hiera.yaml
+++ b/vagrant/hiera.yaml
@@ -1,0 +1,31 @@
+---
+# This is a copy of puppet/hiera.yaml but with an additional vagrant layer
+version: 5
+defaults:  # Used for any hierarchy level that omits these keys.
+  # The default value for "datadir" is "data" under the same directory as the hiera.yaml
+  # file (this file)
+  # When specifying a datadir, make sure the directory exists.
+  # See https://puppet.com/docs/puppet/latest/environments_about.html for further details on environments.
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Per-node data"
+    path: "nodes/%{trusted.certname}.yaml"
+
+  - name: "Per-OS major defaults"
+    path: "os/%{facts.os.name}-%{facts.os.release.major}.yaml"
+
+  - name: "Per-OS defaults"
+    path: "os/%{facts.os.name}.yaml"
+
+  - name: "Per-OS family major defaults"
+    path: "osfamily/%{facts.os.family}-%{facts.os.release.major}.yaml"
+
+  - name: "Per-OS family defaults"
+    path: "osfamily/%{facts.os.family}.yaml"
+
+  - name: "Other YAML hierarchy levels"
+    paths:
+      - "vagrant.yaml"
+      - "common.yaml"

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -1,44 +1,21 @@
 node /^jenkins-master.*/ {
-  class { 'profiles::jenkins::controller':
-    hostname                     => $facts['networking']['fqdn'],
-    https                        => false,
-    jenkins_job_builder          => true,
-    jenkins_job_builder_username => 'admin',
-    jenkins_job_builder_password => 'changeme',
-  }
+  include profiles::jenkins::controller
 }
 
-node /^jenkins-node.*/ {
+node /^jenkins-(deb-)?node.*/ {
   sudo::conf { 'vagrant':
     content => 'vagrant ALL=(ALL) NOPASSWD: ALL',
   }
 
-  class { 'profiles::jenkins::node':
-    swap_size_mb => 0,
-  }
-}
-
-node /^jenkins-deb-node.*/ {
-  sudo::conf { 'vagrant':
-    content => 'vagrant ALL=(ALL) NOPASSWD: ALL',
-  }
-
-  class { 'profiles::jenkins::node':
-    swap_size_mb => 0,
-    unittests    => false,
-  }
+  include profiles::jenkins::node
 }
 
 node /^web.*/ {
-  class { 'profiles::web':
-    https => false,
-  }
+  include profiles::web
 }
 
 node /^backup.*/ {
-  class { 'profiles::backup::receiver':
-    targets => ['redmine', 'jenkins-master'],
-  }
+  include profiles::backup::receiver
 }
 
 node /^redmine.*/ {


### PR DESCRIPTION
The initial goal was to allow setting the password via Hiera, but then I figured that this also closer aligns the actual deployments. At some point it may be possible to use the same manifest file for both production and vagrant.

This does leak some Vagrant details into the deployed production environment. That could be mitigated by excluding the vagrant.yaml file, but it's not that big of a deal.