### PR TITLE
Ensure jenkins_job_builder is EL9 compatible

### DIFF
--- a/puppet/data/common.yaml
+++ b/puppet/data/common.yaml
@@ -11,6 +11,9 @@ foreman_proxy::trusted_hosts:
   - "foreman01.conova.theforeman.org"
 foreman_proxy::foreman_base_url: '%{alias("foreman_url")}'
 
+# Foreman's jenkins-jobs is incompatible with JJB 5
+jenkins_job_builder::ensure: '4.3.0'
+
 profiles::backup::receiver::targets:
   - redmine01
   - master02

--- a/puppet/modules/jenkins_job_builder/manifests/config.pp
+++ b/puppet/modules/jenkins_job_builder/manifests/config.pp
@@ -14,12 +14,16 @@ define jenkins_job_builder::config (
   $directory = '/etc/jenkins_jobs'
   $inifile = "${directory}/jenkins_jobs_${config_name}.ini"
 
+  $git = if $facts['os']['release']['major'] == '7' { 'git' } else { 'git-core' }
+  ensure_packages([$git])
+
   vcsrepo { "${directory}/${git_project_name}":
     ensure   => latest,
     provider => git,
     source   => $git_repo,
     revision => $git_ref,
     notify   => Exec["jenkins-jobs-update-${config_name}"],
+    require  => Package[$git],
   }
 
   exec { "jenkins-jobs-update-${config_name}":

--- a/puppet/modules/jenkins_job_builder/manifests/init.pp
+++ b/puppet/modules/jenkins_job_builder/manifests/init.pp
@@ -4,12 +4,16 @@
 # Loosely based on
 # https://git.openstack.org/cgit/openstack-infra/puppet-jenkins/tree/manifests/job_builder.pp
 # and should probably be kept up to date from there
+
+# @param ensure
+#   The package state to ensure. Can be installed or a specific version.
 #
 # @param configs
 #   A hash of: 'name' => 'url', 'username', 'password'
 #   The name matches the name under files/ of the config directory.
 #
 class jenkins_job_builder (
+  String[1] $ensure = installed,
   Hash[String, Hash] $configs = {},
 ) {
   contain jenkins_job_builder::install


### PR DESCRIPTION
The YAML package name has changed. It now also ensures git is installed and stops ensuring python-jenkins explicitly, relying on pip to do dependency resolution for us.

It pins to version 4.3.0, which is the last version before 5 given that Foreman's jenkins-jobs repository is not compatible with it. I started https://github.com/theforeman/jenkins-jobs/pull/329 but that's bigger than I thought so it pins for now.