### PR TITLE
Avoid globs in backup paths

### DIFF
--- a/puppet/modules/profiles/manifests/discourse.pp
+++ b/puppet/modules/profiles/manifests/discourse.pp
@@ -9,6 +9,6 @@ class profiles::discourse {
 
   restic::repository { 'discourse':
     backup_cap_dac_read_search => true,
-    backup_path                => ["${root}/containers", "${root}/shared/*/backups"],
+    backup_path                => ["${root}/containers", "${root}/shared/standalone/backups"],
   }
 }


### PR DESCRIPTION
This doesn't work and it's just a single directory at the moment.