### PR TITLE
Revert "Remove tito from our RPM builders"

### DIFF
--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -70,13 +70,25 @@ class slave::packaging::rpm (
   }
 
   unless $is_el8 {
-    # Tito was used in the past, but no longer. This cleans up the files we used to have.
+    # tito
+    # Work around to fix https://github.com/rpm-software-management/tito/pull/354#issuecomment-613523823
+    # Pulled from the infra repository
     package { 'tito':
-      ensure => absent,
+      ensure => '0.6.12',
     }
 
     file { "${homedir}/.titorc":
-      ensure => absent,
+      ensure  => file,
+      mode    => '0644',
+      owner   => 'jenkins',
+      group   => 'jenkins',
+      content => "KOJI_OPTIONS=-c ~/.koji/config build --nowait\n",
+    }
+
+    file { '/tmp/tito':
+      ensure => directory,
+      owner  => 'jenkins',
+      group  => 'jenkins',
     }
   }
 

--- a/puppet/modules/unattended/manifests/init.pp
+++ b/puppet/modules/unattended/manifests/init.pp
@@ -21,7 +21,7 @@ class unattended {
     class { 'yum_cron':
       apply_updates    => true,
       mailto           => 'sysadmins',
-      exclude_packages => ['kernel*', 'java*', 'jenkins'],
+      exclude_packages => ['kernel*', 'java*', 'jenkins', 'tito'],
     }
   }
 }


### PR DESCRIPTION
This reverts commit 61cca97c19bf28c93bc952e3f573f66040c459a7.


I forgot pulpcore-packaging was still using the tito method :/ Let's put this back and I will work on swapping it over.