### PR TITLE
Declare Foreman 3.7 as stable

### DIFF
--- a/puppet/modules/profiles/manifests/web.pp
+++ b/puppet/modules/profiles/manifests/web.pp
@@ -18,7 +18,7 @@
 #   Maximum connection per rsync target. Using a small value to try and reduce
 #   server load
 class profiles::web (
-  String[1] $stable = '3.6',
+  String[1] $stable = '3.7',
   String[1] $next = '3.8',
   Hash[String, Hash] $debugs_htpasswds = {},
   Boolean $https = true,


### PR DESCRIPTION
It went GA quite a while back and and this makes sure the latest symlinks redirect to the correct version.