### PR TITLE
Drop conditionals for Debian packaging for non-d11

### DIFF
--- a/puppet/modules/slave/manifests/packaging/debian.pp
+++ b/puppet/modules/slave/manifests/packaging/debian.pp
@@ -10,13 +10,7 @@ class slave::packaging::debian(
     ensure => present,
   }
 
-  if $facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '11') >= 0 {
-    ensure_packages(['python3-pip', 'python3-setuptools'])
-  } else {
-    ensure_packages(['python-pip', 'python-setuptools'])
-  }
-
-  ensure_packages(['zstd'])
+  ensure_packages(['python3-pip', 'python3-setuptools', 'zstd'])
 
   if $facts['os']['name'] == 'Debian' {
     include apt::backports


### PR DESCRIPTION
Previously there were builders on Debian < 11, but those have been retired and we can simplify the code to just current Debian.