### PR TITLE
Use rsync::receiver_setup for stagingyum

### DIFF
--- a/puppet/modules/web/manifests/vhost/stagingyum.pp
+++ b/puppet/modules/web/manifests/vhost/stagingyum.pp
@@ -27,7 +27,7 @@ class web::vhost::stagingyum (
     },
   ]
 
-  secure_ssh::receiver_setup { $user:
+  secure_ssh::rsync::receiver_setup { $user:
     user           => $user,
     homedir        => $home,
     homedir_mode   => '0750',


### PR DESCRIPTION
This should setup this up more properly and fix the key mismatch issue.