### PR TITLE
Allow and remove old yumstage key

### DIFF
--- a/puppet/modules/secure_ssh/manifests/rsync/uploader_key.pp
+++ b/puppet/modules/secure_ssh/manifests/rsync/uploader_key.pp
@@ -20,8 +20,10 @@ define secure_ssh::rsync::uploader_key (
   Stdlib::Absolutepath $dir = "/home/${user}/.ssh",
   Stdlib::Filemode $mode = '0600',
   Boolean $manage_dir = false,
+  String[1] $ensure = 'present',
 ) {
   secure_ssh::uploader_key { $name:
+    ensure       => $ensure,
     user         => $user,
     dir          => $dir,
     mode         => $mode,

--- a/puppet/modules/secure_ssh/manifests/uploader_key.pp
+++ b/puppet/modules/secure_ssh/manifests/uploader_key.pp
@@ -21,6 +21,7 @@ define secure_ssh::uploader_key (
   Stdlib::Filemode $mode = '0600',
   Boolean $manage_dir = false,
   String[1] $ssh_key_name = "${name}_key",
+  String[1] $ensure = 'present',
 ) {
   $pub_key  = ssh::keygen($ssh_key_name, true)
   $priv_key = ssh::keygen($ssh_key_name)
@@ -34,12 +35,14 @@ define secure_ssh::uploader_key (
   }
 
   file { "${dir}/${ssh_key_name}":
+    ensure  => $ensure,
     owner   => $user,
     mode    => '0400',
     content => $priv_key,
   }
 
   file { "${dir}/${ssh_key_name}.pub":
+    ensure  => $ensure,
     owner   => $user,
     mode    => '0644',
     content => "ssh-rsa ${pub_key} ${ssh_key_name} from puppetmaster\n",

--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -111,4 +111,9 @@ class slave::packaging::rpm (
   }
 
   include rsync
+
+  secure_ssh::rsync::uploader_key { 'yumstage':
+    ensure => 'absent',
+    user   => $user,
+  }
 }


### PR DESCRIPTION
I thought the naming was the issue with why the key in the `authorized_keys` was not matching the key on the Jenkins nodes but not the case. Thus I created an unused key and this allows cleaning it up.

