### PR TITLE
Add updated HEADER, and missing stagingyum entries

### DIFF
--- a/docs/webserver.md
+++ b/docs/webserver.md
@@ -19,6 +19,7 @@ These domains are all hosted on the webserver.
 * downloads.theforeman.org
 * stagingdeb.theforeman.org
 * yum.theforeman.org
+* stagingyum.theforeman.org
 * rsync.theforeman.org
 
 ### Fastly CDN
@@ -29,6 +30,7 @@ A Fastly CDN exists that sits in front of:
 * downloads.theforeman.org
 * stagingdeb.theforeman.org
 * yum.theforeman.org
+* stagingyum.theforeman.org
 
 For these, the webserver acts as a backend while the content is served from the Fastly CDN to users.
 

--- a/puppet/modules/web/files/stagingyum/HEADER.html
+++ b/puppet/modules/web/files/stagingyum/HEADER.html
@@ -1,0 +1,17 @@
+<h1>stagingyum.theforeman.org</h1>
+
+<h3>Staging Repositories for Foreman releases</h3>
+
+<h3>Accessing this repo</h3>
+
+This repository is available over HTTP, HTTPS and rsync:
+
+<ul>
+  <li>http://stagingyum.theforeman.org</li>
+  <li>https://stagingyum.theforeman.org</li>
+  <li>rsync://rsync.theforeman.org/stagingyum</li>
+</ul>
+
+<h3>Support</h3>
+
+<p>These are staging repositories used for testing purposes only. They are NOT supported.</p>

--- a/puppet/modules/web/files/stagingyum/robots.txt
+++ b/puppet/modules/web/files/stagingyum/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /foreman/
+Disallow: /plugins/
+Disallow: /katello/
+Disallow: /client/
+Disallow: /pulpcore/

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -30,6 +30,7 @@ class web(
         'stagingdeb.theforeman.org',
         'www.theforeman.org',
         'yum.theforeman.org',
+        'stagingyum.theforeman.org',
       ],
       webroot_paths => [
         '/var/www/vhosts/web/htdocs',
@@ -40,6 +41,7 @@ class web(
         '/var/www/vhosts/stagingdeb/htdocs',
         '/var/www/vhosts/web/htdocs',
         '/var/www/vhosts/yum/htdocs',
+        '/var/www/vhosts/stagingyum/htdocs',
       ],
     }
   }


### PR DESCRIPTION
Is this enough to get a DNS entry for `stagingyum.theforeman.org` or do I need @ekohl / @evgeni to add one?