### PR TITLE
Revert "Revert "Remove tito from our RPM builders""

### DIFF
--- a/puppet/modules/slave/manifests/packaging/rpm.pp
+++ b/puppet/modules/slave/manifests/packaging/rpm.pp
@@ -72,25 +72,13 @@ class slave::packaging::rpm (
   }
 
   unless $is_el8 {
-    # tito
-    # Work around to fix https://github.com/rpm-software-management/tito/pull/354#issuecomment-613523823
-    # Pulled from the infra repository
+    # Tito was used in the past, but no longer. This cleans up the files we used to have.
     package { 'tito':
-      ensure => '0.6.12',
+      ensure => absent,
     }
 
     file { "${homedir}/.titorc":
-      ensure  => file,
-      mode    => '0644',
-      owner   => 'jenkins',
-      group   => 'jenkins',
-      content => "KOJI_OPTIONS=-c ~/.koji/config build --nowait\n",
-    }
-
-    file { '/tmp/tito':
-      ensure => directory,
-      owner  => 'jenkins',
-      group  => 'jenkins',
+      ensure => absent,
     }
   }
 

--- a/puppet/modules/unattended/manifests/init.pp
+++ b/puppet/modules/unattended/manifests/init.pp
@@ -21,7 +21,7 @@ class unattended {
     class { 'yum_cron':
       apply_updates    => true,
       mailto           => 'sysadmins',
-      exclude_packages => ['kernel*', 'java*', 'jenkins', 'tito'],
+      exclude_packages => ['kernel*', 'java*', 'jenkins'],
     }
   }
 }


### PR DESCRIPTION
By now Pulp has also converted and we can really remove tito.

This reverts commit 636eae9f62184865cceb41aa54142d08a5de7f11.