### PR TITLE
Set the next version to Foreman 3.9

### DIFF
--- a/puppet/modules/profiles/manifests/web.pp
+++ b/puppet/modules/profiles/manifests/web.pp
@@ -19,7 +19,7 @@
 #   server load
 class profiles::web (
   String[1] $stable = '3.7',
-  String[1] $next = '3.8',
+  String[1] $next = '3.9',
   Hash[String, Hash] $debugs_htpasswds = {},
   Boolean $https = true,
   Integer[0] $rsync_max_connections = 10,


### PR DESCRIPTION
Foreman 3.8 has branched a while back and this reflects that nightly is now 3.9.