### PR TITLE
Use checksum to detect RPM changes and drop the use of --archive

### DIFF
--- a/puppet/modules/web/files/deploy-yumrepo.sh
+++ b/puppet/modules/web/files/deploy-yumrepo.sh
@@ -17,7 +17,7 @@ prepcache() {
 }
 
 do_rsync() {
-	opts=(--archive --verbose --hard-links --log-file "$REPO_RSYNC_LOG")
+	opts=(--checksum --perms --recursive --links --verbose --hard-links --log-file "$REPO_RSYNC_LOG")
 	if [[ $MERGE != true ]] ; then
 		opts+=('--delete')
 	fi


### PR DESCRIPTION
The --archive option includes --times implicitly that preserves modification time and results in all RPMs being thought of as changed. Instead we explicitly define the options that are included in --archive and drop the use of --times.

We need to apply some of the same rsync logic here to ensure we do not re-copy the RPMs each and every time. As you can see from this test (https://ci.theforeman.org/blue/organizations/jenkins/foreman-nightly-rpm-pipeline/detail/foreman-nightly-rpm-pipeline/2076/pipeline/) pipeline all the files were copied over from stagingyum.