### PR TITLE
Update yum header to list more URLs

### DIFF
--- a/puppet/modules/web/files/yum/HEADER.html
+++ b/puppet/modules/web/files/yum/HEADER.html
@@ -1,11 +1,11 @@
 <h1>yum.theforeman.org</h1>
 
-<h3>Stable Foreman releases</h3>
+<h3>Foreman</h3>
 
-<p>Releases are available under <code>/releases/VERSION/DIST/ARCH</code>, e.g.</p>
+<p>Foreman is available under <code>/releases/VERSION/DIST/ARCH</code>, e.g.</p>
 
 <ul>
-  <li>/releases/3.4/el8/x86_64</li>
+  <li>/releases/3.8/el8/x86_64</li>
   <li>/releases/nightly/el8/x86_64</li>
 </ul>
 
@@ -13,17 +13,14 @@
 
 <ul>
   <li><a href="https://yum.theforeman.org/releases/latest/el8/x86_64/foreman-release.rpm">https://yum.theforeman.org/releases/latest/el8/x86_64/foreman-release.rpm</a></li>
+  <li><a href="https://yum.theforeman.org/releases/nightly/el8/x86_64/foreman-release.rpm">https://yum.theforeman.org/releases/nightly/el8/x86_64/foreman-release.rpm</a></li>
 </ul>
 
 <p>Release packages <a href="https://theforeman.org/security.html#GPGkeys">are signed with a new key for each major release</a>.  The public key is available in the RPM-GPG-KEY-foreman file within each version directory or the foreman-release RPMs.</p>
 
+<p>Nightly builds of Foreman are available under <code>/releases/nightly/DIST/ARCH</code> and are refreshed a few times a day, but are not GPG signed.</p>
+
 <p>A symlink is available at <code>/releases/latest</code> which always points to the latest stable release.  Please be careful when using this, as release upgrades often require some manual intervention (see release notes).</p>
-
-<h3>Nightly builds and release candidates</h3>
-
-<p>Nightly builds of Foreman are available under <code>/nightly/DIST/ARCH</code> and are refreshed a few times a day, but are not GPG signed.</p>
-
-<p>Release candidates are in the versioned directories under <code>/releases</code>.  These are GPG-signed like stable packages.</p>
 
 <h3>Plugins</h3>
 
@@ -32,11 +29,24 @@
 <p>Plugin repos are structured by the Foreman version that they're compatible with in the format <code>/plugins/VERSION/DIST/ARCH</code>, e.g.</p>
 
 <ul>
-  <li>/plugins/3.4/el8/x86_64</li>
+  <li>/plugins/3.8/el8/x86_64</li>
   <li>/plugins/nightly/el8/x86_64</li>
 </ul>
 
 <p>Plugin repos are not GPG signed.</p>
+
+<h3>Katello</h3>
+
+<p>Katello is available under <code>/katello/VERSION/katello/DIST/ARCH</code> with Candlepin under <code>/katello/VERSION/candlepin/DIST/ARCH</code>.
+
+<p>katello-repos RPMs containing an appropriate .repo file are available:</p>
+
+<ul>
+  <li><a href="https://yum.theforeman.org/katello/4.10/katello/el8/x86_64/katello-repos-latest.rpm">https://yum.theforeman.org/katello/4.10/katello/el8/x86_64/katello-repos-latest.rpm</a></li>
+  <li><a href="https://yum.theforeman.org/katello/nightly/katello/el8/x86_64/katello-repos-latest.rpm">https://yum.theforeman.org/katello/nightly/katello/el8/x86_64/katello-repos-latest.rpm</a></li>
+<ul>
+
+<p>Unlike Foreman, there is no <code>latest</code> symlink and you must match the Katello version to the correct Foreman version</p>
 
 <h3>Accessing this repo</h3>
 


### PR DESCRIPTION
Often I want to quickly get the URL for the nightly foreman-release to test out some changes. This makes it easier. It also documents Katello's release repos. To make it a bit easier to see, the Foreman section is shortened.