### PR TITLE
Calculate release for staginyum rsync script properly

### DIFF
--- a/puppet/modules/web/templates/deploy-stagingyum.sh.erb
+++ b/puppet/modules/web/templates/deploy-stagingyum.sh.erb
@@ -1,7 +1,8 @@
   # Make sure target dir can be created
-  YUM_PATH=`echo "${SSH_ORIGINAL_COMMAND}" | awk '{ print $NF }'`
-  PROJECT=`echo $YUM_PATH | /bin/cut -f2 -d/`
-  RELEASE=`echo $YUM_PATH | /bin/cut -f3 -d/`
+  YUM_PATH=`echo "${SSH_ORIGINAL_COMMAND}" | awk '{ print $(NF-1) }'`
+  PROJECT=`echo $YUM_PATH | awk -F/ '{print $(NF-1)}' | tr -d '"'`
+  RELEASE=`echo $YUM_PATH | awk -F/ '{print $NF}' | tr -d '"'`
+
   mkdir -p <%= @home %>/rsync_cache/$PROJECT/$RELEASE
 
   # Permit transfer


### PR DESCRIPTION
The command we send is:

`SSH_ORIGINAL_COMMAND='rsync --checksum --perms --recursive --links -v --one-file-system --delete-after --partial "tmp/pulpcore/nightly" "yumrepostage@web01.osuosl.theforeman.org:rsync_cache/pulpcore"'`

And with the current version this results in:

```
"yumrepostage@web01.osuosl.theforeman.org:rsync_cache/pulpcore"
pulpcore"

```

With this change, it ends up trying to rsync everything:

```
rsync -rvx --delete-after /home/yumrepostage/rsync_cache/pulpcore/ /var/www/vhosts/stagingyum/htdocs/pulpcore/
```