### PR TITLE
Update ruby 2.7 to 2.7.8

### DIFF
--- a/puppet/modules/slave/manifests/rvm.pp
+++ b/puppet/modules/slave/manifests/rvm.pp
@@ -33,7 +33,7 @@ class slave::rvm {
       version => 'ruby-2.6.3',
     }
     slave::rvm_config { 'ruby-2.7':
-      version          => 'ruby-2.7.4',
+      version          => 'ruby-2.7.8',
       rubygems_version => '3.1.6',
     }
     slave::rvm_config { 'ruby-3.0':


### PR DESCRIPTION
Trying to resolve an issue with https://github.com/Katello/katello/pull/10824

In CI, that was failing with:

```
[2023-12-12T21:28:51.917Z] Error:

[2023-12-12T21:28:51.917Z] CdnResourceTest#test_http_downloader_tlsv13:

[2023-12-12T21:28:51.917Z] NameError: uninitialized constant OpenSSL::SSL::TLS1_3_VERSION

[2023-12-12T21:28:51.917Z] Did you mean?  OpenSSL::SSL::TLS1_1_VERSION

[2023-12-12T21:28:51.917Z]                OpenSSL::SSL::TLS1_2_VERSION

[2023-12-12T21:28:51.917Z]                OpenSSL::SSL::TLS1_VERSION

[2023-12-12T21:28:51.917Z]                OpenSSL::SSL::SSL3_VERSION

[2023-12-12T21:28:51.917Z]     /home/jenkins/workspace/katello-pr-test/app/lib/katello/resources/cdn.rb:115:in `const_get'

[2023-12-12T21:28:51.917Z]     /home/jenkins/workspace/katello-pr-test/app/lib/katello/resources/cdn.rb:115:in `http_downloader'

[2023-12-12T21:28:51.917Z]     /home/jenkins/workspace/katello-pr-test/test/lib/resources/cdn_test.rb:24:in `test_http_downloader_tlsv13'
```

In nightlies and in my dev environment, with ruby 2.7.8, that issue is not occurring.