### PR TITLE
Use --force with puppet generate types

### DIFF
--- a/puppet/modules/deploy/files/script.sh
+++ b/puppet/modules/deploy/files/script.sh
@@ -7,5 +7,5 @@ trap 'rm -rf ${dir}' EXIT
 git clone --quiet --depth 1 https://github.com/theforeman/foreman-infra "${dir}/"
 g10k -quiet -cachedir "$HOME/.cache/g10k" -puppetfile -puppetfilelocation "${dir}/puppet/Puppetfile" -moduledir "${dir}/puppet/external_modules"
 rsync -aqx --delete-after --exclude=.git "${dir}"/puppet/* "/etc/puppetlabs/code/environments/$environment/"
-puppet generate types --environment "$environment" --config /etc/puppetlabs/puppet/puppet.conf
+puppet generate types --environment "$environment" --config /etc/puppetlabs/puppet/puppet.conf --force
 echo "Deploy complete at $(date)"


### PR DESCRIPTION
When installing a new module it maintains the file timestamps from the original tarball. puppet generate types uses the timestamp of when it ran.

If you update a module to a release that was created before it ran puppet types generate, it will never update the types. This can happen with a module downgrade, or just when you regenerated types manually. By using --force the timestamps are ignored.