### PR TITLE
Fix support info on the Downloads page

### DIFF
--- a/puppet/modules/web/files/downloads-HEADER.html
+++ b/puppet/modules/web/files/downloads-HEADER.html
@@ -12,6 +12,7 @@
 
 <p>You can find installation instructions <a href="http://theforeman.org/manuals/latest/index.html#3.3InstallFromPackages">here</a>, but we strongly recommend using our <a href="http://theforeman.org/manuals/latest/index.html#3.2ForemanInstaller">Installer</a>.
 
-<p>If you have any issues, you can find the forum at <a href="https://community.theforeman.org/">community.theforeman.org</a> or on IRC (<a href="https://libera.chat/">libera.chat</a>, <a href="irc://irc.libera.chat/theforeman">#theforeman</a>)</p>
+<p>If you have any issues, see <a href="https://theforeman.org/support.html">Support</a> for community guidelines and support options.</p>
 <br/>
 </body>
+


### PR DESCRIPTION
Current support info on https://downloads.theforeman.org/ is outdated.
Let's link to the Support page so that we don't have to update it every time we change something regarding Support.
