### PR TITLE
exclude kmod updates, they can depend on newer kernels

### DIFF
--- a/puppet/modules/unattended/manifests/init.pp
+++ b/puppet/modules/unattended/manifests/init.pp
@@ -21,7 +21,7 @@ class unattended {
     class { 'yum_cron':
       apply_updates    => true,
       mailto           => 'sysadmins',
-      exclude_packages => ['kernel*', 'java*', 'jenkins'],
+      exclude_packages => ['kernel*', 'kmod-*', 'java*', 'jenkins'],
     }
   }
 }


### PR DESCRIPTION
this breaks the whole update transaction and *NO* updates are applied
