### PR TITLE
stop rewriting $next to nightly

### DIFF
--- a/puppet/modules/profiles/manifests/web.pp
+++ b/puppet/modules/profiles/manifests/web.pp
@@ -3,9 +3,6 @@
 # @param stable
 #   Latest release that users expect
 #
-# @param next
-#   Next release (current nightly). To be updated as part of branching.
-#
 # @param debugs_htpasswds
 #   Which htpasswds to create for the debug vhost
 #
@@ -19,7 +16,6 @@
 #   server load
 class profiles::web (
   String[1] $stable = '3.10',
-  String[1] $next = '3.11',
   Hash[String, Hash] $debugs_htpasswds = {},
   Boolean $https = true,
   Integer[0] $rsync_max_connections = 10,
@@ -51,7 +47,6 @@ class profiles::web (
 
   class { 'web::vhost::web':
     stable => $stable,
-    next   => $next,
   }
   contain web::vhost::web
 

--- a/puppet/modules/web/manifests/vhost/web.pp
+++ b/puppet/modules/web/manifests/vhost/web.pp
@@ -2,7 +2,6 @@
 # @api private
 class web::vhost::web(
   String[1] $stable,
-  String[1] $next,
   Stdlib::Absolutepath $web_directory = '/var/www/vhosts/web/htdocs',
 ) {
   require web
@@ -32,7 +31,6 @@ class web::vhost::web(
 
   $docs_rewrites = [
     { 'rewrite_rule' => ["^/manuals/latest(.*) /manuals/${stable}\$1 [R,L]"] },
-    { 'rewrite_rule' => ["^/manuals/${next}(.*) /manuals/nightly\$1 [R,L]"] },
   ]
 
   $directory_config = [


### PR DESCRIPTION
Foreman correctly generates "nightly" links since https://github.com/theforeman/foreman/pull/10155
