### PR TITLE
add backend serveraliases to debian vhosts

### DIFF
--- a/puppet/modules/freight/manifests/user.pp
+++ b/puppet/modules/freight/manifests/user.pp
@@ -70,6 +70,8 @@ define freight::user (
   include apache::mod::mime
 
   web::vhost { $vhost:
+    servername    => "${vhost}-backend.${facts['networking']['fqdn']}",
+    serveraliases => [ "${vhost}.theforeman.org" ],
     docroot       => $webdir,
     docroot_owner => $user,
     docroot_group => $user,


### PR DESCRIPTION
deb.tfm.o (and friends) do not point to our host these days, but to a
CDN, thus, using deb.tfm.o as the vhost name is a tad wrong.

this change introduces two aliases for the vhost: deb-backend.tfm.o and
deb.${fqdn}, which in my test environment results in:

    ServerName deb.theforeman.org
    ServerAlias deb-backend.theforeman.org
    ServerAlias deb.repo-deb.tanso.example.com

This has the benefit that the right vhost is reachable without any
tricks, and will allow us to switch the CDN config to a "more correct"
naming scheme, later dropping deb.tfm.o from the vhost here totally.

(This has the side-benefit that deb.tfm LE requests go via the CDN and
only then hit our box, which is confusing to say the least and that
would stop)
