### PR TITLE
Split out letsencrypt for web

### DIFF
--- a/puppet/modules/profiles/manifests/repo/rpm.pp
+++ b/puppet/modules/profiles/manifests/repo/rpm.pp
@@ -12,7 +12,8 @@ class profiles::repo::rpm (
   Boolean $https = true,
 ) {
   class { 'web':
-    https => $https,
+    https      => $https,
+    all_in_one => false,
   }
   contain web
 

--- a/puppet/modules/web/manifests/certs.pp
+++ b/puppet/modules/web/manifests/certs.pp
@@ -1,0 +1,20 @@
+# @summary Define letsencrypt certificate
+#
+# domain / webroot_paths must match exactly
+#
+# @param domains
+#   Domains to be handled by the certificate
+# @param paths
+#   Vhost paths for each domain
+define web::certs(
+  Array[String] $domains,
+  Array[String] $paths,
+) {
+  $letsencypt_domain = 'theforeman.org'
+
+  letsencrypt::certonly { $letsencypt_domain:
+    plugin        => 'webroot',
+    domains       => $domains,
+    webroot_paths => $paths,
+  }
+}

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -8,19 +8,19 @@
 #   start httpd, the certs have to exist, so keep SSL vhosts disabled until the
 #   certs are present via the HTTP vhost and only then enable the SSL vhosts.
 #
+# @param all_in_one
+#   Used when deploying all vhosts to the same machine.
+#
 class web(
   Boolean $https = false,
+  Boolean $all_in_one = true,
 ) {
   class { 'web::base':
     letsencrypt => $https,
   }
 
-  if $https {
-    $letsencypt_domain = 'theforeman.org'
-
-    letsencrypt::certonly { $letsencypt_domain:
-      plugin        => 'webroot',
-      # domain / webroot_paths must match exactly
+  if $https and $all_in_one {
+    web::certs { 'web':
       domains       => [
         'theforeman.org',
         'archivedeb.theforeman.org',

--- a/puppet/modules/web/manifests/vhost/rpm.pp
+++ b/puppet/modules/web/manifests/vhost/rpm.pp
@@ -40,6 +40,23 @@ class web::vhost::rpm (
     script_content => epp('web/deploy-rpmrepo.sh.epp', $deploy_rpmrepo_context),
   }
 
+  if $web::https {
+    web::certs { 'rpm':
+      domains       => [
+        'yum.theforeman.org',
+        'stagingyum.theforeman.org',
+        'rpm.theforeman.org',
+        'stagingrpm.theforeman.org',
+      ],
+      webroot_paths => [
+        '/var/www/vhosts/yum/htdocs',
+        '/var/www/vhosts/stagingyum/htdocs',
+        '/var/www/vhosts/rpm/htdocs',
+        '/var/www/vhosts/stagingrpm/htdocs',
+      ],
+    }
+  }
+
   include apache::mod::expires
   include apache::mod::dir
   include apache::mod::autoindex


### PR DESCRIPTION
We need to split out letsencrypt certificate setup since we are splitting up our web content across multiple servers. In the current format, this will fail to setup rpm and debian content servers. I am aiming to introduce a reusable defines to solve this but it does present a conundrum still. In theory the various vhosts are independent, but the certificate that gets generated is tied to the machine so that we have a single entity but requires knowledge of the vhosts.

Should I instead be doing this at the profile level? Is that leaking internals to the profile?