### PR TITLE
explicitly resolve A/AAAA when pulling external IP from icanhazip

### DIFF
--- a/puppet/modules/profiles/lib/facter/external_ips.rb
+++ b/puppet/modules/profiles/lib/facter/external_ips.rb
@@ -1,9 +1,15 @@
-require 'open-uri'
+require 'net/http'
+require 'resolv'
 
 Facter.add(:external_ip4) do
   setcode do
     begin
-      URI.parse('http://ipv4.icanhazip.com/').read.chomp
+      Resolv::DNS.open do |dns|
+        addr = dns.getresource("ipv4.icanhazip.com", Resolv::DNS::Resource::IN::A).address.to_s
+        Net::HTTP.start(addr) do |http|
+          http.get('http://ipv4.icanhazip.com/').body.chomp
+        end
+      end
     rescue
       nil
     end
@@ -13,7 +19,12 @@ end
 Facter.add(:external_ip6) do
   setcode do
     begin
-      URI.parse('http://ipv6.icanhazip.com/').read.chomp
+      Resolv::DNS.open do |dns|
+        addr = dns.getresource("ipv6.icanhazip.com", Resolv::DNS::Resource::IN::AAAA).address.to_s
+        Net::HTTP.start(addr) do |http|
+          http.get('http://ipv6.icanhazip.com/').body.chomp
+        end
+      end
     rescue
       nil
     end


### PR DESCRIPTION
ipv4.icanhazip.com has an AAAA record, and ipv6 has an A record, which
leads to both facts returning v6 addresses.

while this is a missconfiguration on the side of icanhazip.com, we can
prevent it from happening by forcing things at the resolver level.
