### PR TITLE
set sni_hostname for Fastly

### DIFF
--- a/ansible/fastly.yml
+++ b/ansible/fastly.yml
@@ -18,6 +18,7 @@
             port: 443
             shield: iad-va-us
             ssl_cert_hostname: "{{ item }}.theforeman.org"
+            ssl_sni_hostname: "{{ item }}.theforeman.org"
             healthcheck: HEADER.html
         conditions:
           - name: error log


### PR DESCRIPTION
otherwise health checks fail
