### PR TITLE
simplify https handling by dropping the profile parameter

### DIFF
--- a/puppet/data/vagrant.yaml
+++ b/puppet/data/vagrant.yaml
@@ -20,9 +20,6 @@ profiles::jenkins::controller::jenkins_job_builder_username: "admin"
 
 profiles::jenkins::node::swap_size_mb: 0
 
-profiles::web::https: false
-
-profiles::repo::deb::https: false
-profiles::repo::rpm::https: false
-
 redmine::https: false
+
+web::https: false

--- a/puppet/modules/profiles/manifests/repo/deb.pp
+++ b/puppet/modules/profiles/manifests/repo/deb.pp
@@ -2,18 +2,9 @@
 #
 # @param stable
 #   Latest release that users expect
-#
-# @param https
-#   Whether to enable HTTPS. This is typically wanted but can only be enabled
-#   in a 2 pass setup. First Apache needs to run for Letsencrypt to function.
-#   Then Letsencrypt can be enabled. Also useful to turn off in test setups.
 class profiles::repo::deb (
   String[1] $stable,
-  Boolean $https = true,
 ) {
-  class { 'web':
-    https => $https,
-  }
   contain web
 
   contain web::vhost::archivedeb

--- a/puppet/modules/profiles/manifests/repo/rpm.pp
+++ b/puppet/modules/profiles/manifests/repo/rpm.pp
@@ -2,18 +2,9 @@
 #
 # @param stable_foreman
 #   Latest Foreman release that users expect
-#
-# @param https
-#   Whether to enable HTTPS. This is typically wanted but can only be enabled
-#   in a 2 pass setup. First Apache needs to run for Letsencrypt to function.
-#   Then Letsencrypt can be enabled. Also useful to turn off in test setups.
 class profiles::repo::rpm (
   String[1] $stable_foreman,
-  Boolean $https = true,
 ) {
-  class { 'web':
-    https => $https,
-  }
   contain web
 
   class { 'web::vhost::rpm':

--- a/puppet/modules/profiles/manifests/web.pp
+++ b/puppet/modules/profiles/manifests/web.pp
@@ -2,18 +2,9 @@
 #
 # @param stable
 #   Latest release that users expect
-#
-# @param https
-#   Whether to enable HTTPS. This is typically wanted but can only be enabled
-#   in a 2 pass setup. First Apache needs to run for Letsencrypt to function.
-#   Then Letsencrypt can be enabled. Also useful to turn off in test setups.
 class profiles::web (
   String[1] $stable,
-  Boolean $https = true,
 ) {
-  class { 'web':
-    https => $https,
-  }
   contain web
 
   contain web::vhost::archivedeb

--- a/puppet/modules/web/manifests/init.pp
+++ b/puppet/modules/web/manifests/init.pp
@@ -9,7 +9,7 @@
 #   certs are present via the HTTP vhost and only then enable the SSL vhosts.
 #
 class web(
-  Boolean $https = false,
+  Boolean $https = true,
 ) {
   include web::base
 

--- a/puppet/spec/classes/profiles_web_spec.rb
+++ b/puppet/spec/classes/profiles_web_spec.rb
@@ -6,12 +6,6 @@ describe 'profiles::web' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile.with_all_deps }
-
-      context 'without https' do
-        let(:params) { { https: false } }
-
-        it { is_expected.to compile.with_all_deps }
-      end
     end
   end
 end


### PR DESCRIPTION
if you need to disable https, use hiera to disable it on the web class
directly

this allows including the web class multiple times, without having to
care that only one includer can pass args
