### PR TITLE
drop old fastly logging remains

### DIFF
--- a/ansible/fastly.yml
+++ b/ansible/fastly.yml
@@ -20,11 +20,6 @@
             ssl_cert_hostname: "{{ item }}.theforeman.org"
             ssl_sni_hostname: "{{ item }}.theforeman.org"
             healthcheck: HEADER.html
-        conditions:
-          - name: error log
-            statement: fastly_info.state == "ERROR" || (resp.status >= 400 && resp.status < 600)
-            type: RESPONSE
-            priority: 10
         healthchecks:
           - name: HEADER.html
             host: "{{ item }}.theforeman.org"
@@ -34,7 +29,6 @@
             window: 2
             initial: 1
             check_interval: 60000
-        cloudfiles: []
       with_items:
         - archivedeb
         - deb


### PR DESCRIPTION
We disabled logging in c2b136c7c26053c1e300a37676878fbdfada2bbe, but the
(unused) condition and the empty cloudfiles definition was kept.

Drop them!
