### PR TITLE
disable freight cron for archivedeb

### DIFF
--- a/puppet/modules/freight/manifests/user.pp
+++ b/puppet/modules/freight/manifests/user.pp
@@ -5,6 +5,7 @@ define freight::user (
   Stdlib::Absolutepath $stagedir,
   String $vhost,
   Variant[String, Array[String]] $cron_matches,
+  Optional[Boolean] $cron_enable = true,
   Optional[String[1]] $stable = undef,
 ) {
   require freight
@@ -29,6 +30,7 @@ define freight::user (
 
   # Cleanup old stuff
   file { "/etc/cron.daily/${user}":
+    ensure  => bool2str($cron_enable, 'file', 'absent'),
     mode    => '0755',
     owner   => 'root',
     group   => 'root',

--- a/puppet/modules/web/manifests/vhost/archivedeb.pp
+++ b/puppet/modules/web/manifests/vhost/archivedeb.pp
@@ -12,6 +12,7 @@ class web::vhost::archivedeb(
     stagedir     => "/var/www/${user}",
     vhost        => 'archivedeb',
     cron_matches => [],
+    cron_enable  => false,
   }
 
   secure_ssh::rsync::receiver_setup { $user:


### PR DESCRIPTION
there is nothing to be cleaned up, so it just wastes a lot of resources
as archivedeb is rather big
