### PR TITLE
drop serveraliases for yum/stagingyum

### DIFF
--- a/puppet/modules/web/manifests/vhost/stagingyum.pp
+++ b/puppet/modules/web/manifests/vhost/stagingyum.pp
@@ -43,7 +43,6 @@ class web::vhost::stagingyum (
 
   web::vhost { 'stagingyum':
     servername    => "stagingyum-backend.${facts['networking']['fqdn']}",
-    serveraliases => [ $servername ],
     docroot       => $yum_directory,
     docroot_owner => $user,
     docroot_group => $user,

--- a/puppet/modules/web/manifests/vhost/yum.pp
+++ b/puppet/modules/web/manifests/vhost/yum.pp
@@ -37,7 +37,6 @@ class web::vhost::yum (
 
   web::vhost { 'yum':
     servername    => "yum-backend.${facts['networking']['fqdn']}",
-    serveraliases => [ $servername ],
     docroot       => $yum_directory,
     docroot_owner => $user,
     docroot_group => $user,


### PR DESCRIPTION
it's now served to fastly via the backend name
