### PR TITLE
Update NodeJS to 18.x on Ubuntu with Foreman 3.14+

### DIFF
--- a/puppet/modules/jenkins_node/files/pbuilder_F66-add-nodesource-repos
+++ b/puppet/modules/jenkins_node/files/pbuilder_F66-add-nodesource-repos
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Nodesource
-if [[ $FOREMAN_VERSION == 3.[0-8] ]]; then
-  nodesrcv="12.x"
-else
+if [[ $FOREMAN_VERSION == 3.1[0-3] ]]; then
   nodesrcv="14.x"
+else
+  nodesrcv="18.x"
 fi
 echo "deb http://deb.nodesource.com/node_${nodesrcv} ${DISTRIBUTION} main" >> /etc/apt/sources.list
 


### PR DESCRIPTION
As part of [dropping NodeJS 14](https://community.theforeman.org/t/drop-debian-11-ruby-2-7-and-nodejs-14-support-in-foreman-3-14/40503) this updates nodesource to NodeJS 18. That's also the version included in Ubuntu 24.04.

It drops the conditionals for Foreman < 3.9 since those are gone now.