### PR TITLE
don't schedule restic forget while restic backup runs

### DIFF
--- a/puppet/data/internal.yaml
+++ b/puppet/data/internal.yaml
@@ -35,7 +35,7 @@ restic::enable_forget: true
 restic::forget:
   keep-daily: 14
   keep-weekly: 4
-restic::forget_timer: 'weekly'
+restic::forget_timer: 'Mon *-*-* 02:00:00'
 restic::prune: true
 # There are no restic packages in EL7 and the ones in EPEL8/9 are too old
 # The ones in Debian are also too old


### PR DESCRIPTION
we run backups "daily", which means "*-*-* 00:00:00"
when we run forget "weekly", this ends up being "Mon *-*-* 00:00:00" and
two writing operations to one repository does not end up well.

instead, let's schedule forgets two hours later.

(setting RandomizedDelaySec on the timers would probably also help a
bit, but would still have a potential for a race condition, so let's
avoid it)
