### PR TITLE
fix rebooting jenkins nodes

### DIFF
--- a/puppet/modules/jenkins_node/files/reboot-jenkins-node
+++ b/puppet/modules/jenkins_node/files/reboot-jenkins-node
@@ -7,5 +7,5 @@ NODE_NAME=$(hostname -f)
 NODE_IDLE=$(curl --fail --silent https://ci.theforeman.org/computer/${NODE_NAME}/api/json/ | jq .idle)
 
 if [[ $NODE_IDLE == true ]]; then
-  shutdown -r 'Rebooting after applying package updates'
+  shutdown -r +5 'Rebooting after applying package updates'
 fi


### PR DESCRIPTION
The time spec was missing, thus resulting in:

    Failed to parse time specification: Rebooting after applying package updates

And no reboot happening.