### PR TITLE
update puppet-lint plugins to allow puppet-lint 5.x

### DIFF
--- a/puppet/Gemfile
+++ b/puppet/Gemfile
@@ -6,15 +6,12 @@ gem 'semantic_puppet'
 gem 'puppet', '~> 7.0', '!= 7.29.0', require: false
 gem 'puppet-lint', require: false
 gem 'puppet-lint-absolute_classname-check', require: false
-gem 'puppet-lint-classes_and_types_beginning_with_digits-check', require: false
-gem 'puppet-lint-empty_string-check', require: false
 gem 'puppet-lint-file_ensure-check', require: false
 gem 'puppet-lint-leading_zero-check', require: false
-gem 'puppet-lint-legacy_facts-check', require: false
+gem 'puppet-lint-params_empty_string-check', require: false
 gem 'puppet-lint-strict_indent-check', require: false
-gem 'puppet-lint-trailing_comma-check', require: false
 gem 'puppet-lint-topscope-variable-check', require: false
-gem 'puppet-lint-undef_in_function-check', require: false
+gem 'puppet-lint-trailing_comma-check', require: false
 gem 'puppet-lint-unquoted_string-check', require: false
 gem 'puppet-lint-variable_contains_upcase', require: false
 gem 'puppet-lint-version_comparison-check', require: false

--- a/puppet/modules/jenkins_node/manifests/init.pp
+++ b/puppet/modules/jenkins_node/manifests/init.pp
@@ -94,7 +94,7 @@ class jenkins_node (
   }
 
   file { ["${homedir}/.config/hub", "${homedir}/.config/copr"]:
-    ensure  => absent,
+    ensure => absent,
   }
 
   package {

--- a/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
+++ b/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
@@ -18,7 +18,7 @@ define jenkins_node::pbuilder_setup (
   }
 
   file { "/etc/pbuilder/${name}/apt.config/sources.list.d":
-    ensure  => bool2str($ensure == present, 'directory', 'absent'),
+    ensure => bool2str($ensure == present, 'directory', 'absent'),
   }
 
   file { "/etc/pbuilder/${name}/apt.config/sources.list.d/debian.list":

--- a/puppet/modules/redmine/manifests/init.pp
+++ b/puppet/modules/redmine/manifests/init.pp
@@ -123,7 +123,7 @@ class redmine (
     command     => 'bundle install --path ./vendor',
     user        => $username,
     cwd         => $app_root,
-    path        => $::path,
+    path        => $facts['path'],
     environment => ["HOME=${app_root}"],
     unless      => 'bundle check',
     require     => Package[$packages],

--- a/puppet/modules/web/manifests/vhost/rpm.pp
+++ b/puppet/modules/web/manifests/vhost/rpm.pp
@@ -75,8 +75,8 @@ class web::vhost::rpm (
     group   => $user,
     mode    => '0644',
     content => epp("${module_name}/rpm/HEADER.html.epp", {
-        'stable_foreman' => $stable_foreman,
-        'servername'     => $servername,
+      'stable_foreman' => $stable_foreman,
+      'servername'     => $servername,
     }),
   }
 

--- a/puppet/modules/web/manifests/vhost/stagingrpm.pp
+++ b/puppet/modules/web/manifests/vhost/stagingrpm.pp
@@ -35,7 +35,7 @@ class web::vhost::stagingrpm (
   include apache::mod::mime
 
   $authorized_keys = flatten($usernames.map |$name| {
-      split(file("users/${name}-authorized_keys"), "\n")
+    split(file("users/${name}-authorized_keys"), "\n")
   })
 
   secure_ssh::rsync::receiver_setup { $user:
@@ -45,8 +45,8 @@ class web::vhost::stagingrpm (
     foreman_search  => 'host ~ node*.jenkins.*.theforeman.org and (name = external_ip4 or name = external_ip6)',
     authorized_keys => $authorized_keys,
     script_content  => epp("${module_name}/deploy-stagingrpm.sh.epp", {
-        'home'                  => $home,
-        'rpm_staging_directory' => $rpm_staging_directory,
+      'home'                  => $home,
+      'rpm_staging_directory' => $rpm_staging_directory,
     }),
   }
 
@@ -73,7 +73,7 @@ class web::vhost::stagingrpm (
     group   => 'root',
     mode    => '0644',
     content => epp("${module_name}/stagingrpm/HEADER.html.epp", {
-        'servername' => $servername,
+      'servername' => $servername,
     }),
   }
 

--- a/puppet/modules/web/manifests/vhost/stagingyum.pp
+++ b/puppet/modules/web/manifests/vhost/stagingyum.pp
@@ -29,7 +29,7 @@ class web::vhost::stagingyum (
   ]
 
   $authorized_keys = flatten($usernames.map |$name| {
-      split(file("users/${name}-authorized_keys"), "\n")
+    split(file("users/${name}-authorized_keys"), "\n")
   })
 
   secure_ssh::rsync::receiver_setup { $user:


### PR DESCRIPTION
this effectively updates puppet-lint from 2.5 (ugh!) to 5.1:

```
-    puppet-lint (2.5.2)
-    puppet-lint-absolute_classname-check (3.1.0)
-      puppet-lint (>= 1.0, < 4)
-    puppet-lint-classes_and_types_beginning_with_digits-check (1.0.0)
-      puppet-lint (>= 1.0, < 3.0)
-    puppet-lint-empty_string-check (1.0.0)
-      puppet-lint (>= 1.0, < 3.0)
-    puppet-lint-file_ensure-check (1.1.0)
-      puppet-lint (>= 1.0, < 4)
-    puppet-lint-leading_zero-check (1.1.0)
-      puppet-lint (>= 1.0, < 4.0)
-    puppet-lint-legacy_facts-check (1.0.4)
-      puppet-lint (~> 2.4)
-    puppet-lint-strict_indent-check (2.1.0)
-      puppet-lint (>= 1.0, < 4)
-    puppet-lint-topscope-variable-check (1.2.0)
-      puppet-lint (>= 2.0, < 4)
-    puppet-lint-trailing_comma-check (1.0.0)
-      puppet-lint (>= 1.0, < 4)
-    puppet-lint-undef_in_function-check (0.2.1)
-      puppet-lint (>= 1.0, < 3.0)
-    puppet-lint-unquoted_string-check (2.2.0)
-      puppet-lint (>= 2.1, < 4)
-    puppet-lint-variable_contains_upcase (1.4.0)
-      puppet-lint (>= 1.0, < 5)
-    puppet-lint-version_comparison-check (1.1.0)
-      puppet-lint (>= 1.0, < 4)
+    puppet-lint (5.1.0)
+    puppet-lint-absolute_classname-check (5.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-file_ensure-check (3.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-leading_zero-check (3.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-params_empty_string-check (3.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-strict_indent-check (5.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-topscope-variable-check (3.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-trailing_comma-check (3.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-unquoted_string-check (4.1.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-variable_contains_upcase (3.0.0)
+      puppet-lint (~> 5.1)
+    puppet-lint-version_comparison-check (3.0.0)
+      puppet-lint (~> 5.1)
```

puppet-lint-classes_and_types_beginning_with_digits-check: obsolete
since Puppet 4

puppet-lint-empty_string-check: replaced with
puppet-lint-params_empty_string-check

puppet-lint-legacy_facts-check: part of puppet-lint since 3.1

puppet-lint-undef_in_function-check: deprecated as Puppet 4 allows that
