### PR TITLE
set debbuildopts to an empty string to fix building on trixie

### DIFF
--- a/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
+++ b/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
@@ -11,10 +11,11 @@ define jenkins_node::pbuilder_setup (
   Boolean $puppetlabs = true,
 ) {
   pbuilder { $name:
-    ensure    => $ensure,
-    arch      => $arch,
-    release   => $release,
-    methodurl => $apturl,
+    ensure       => $ensure,
+    arch         => $arch,
+    release      => $release,
+    methodurl    => $apturl,
+    debbuildopts => '',
   }
 
   file { "/etc/pbuilder/${name}/apt.config/sources.list.d":


### PR DESCRIPTION
the default is -b, which means "binary only", which worked fine until trixie, but now fails as dpkg-genchanges fails to find the .dsc file which is only generated when doing a sourceful build. doing so is not too expensive and I don't want to debug pdebuild any longer.