### PR TITLE
Purge pulpcore repo and postgresql-evr package from Jenkins nodes

### DIFF
--- a/puppet/modules/jenkins_node/manifests/postgresql.pp
+++ b/puppet/modules/jenkins_node/manifests/postgresql.pp
@@ -1,5 +1,22 @@
 # @api private
 class jenkins_node::postgresql {
+  # only CentOS nodes are used to run unit tests
+  if $facts['os']['family'] == 'RedHat' {
+    # Necessary for PostgreSQL EVR extension
+    yumrepo { 'pulpcore':
+      baseurl  => "http://yum.theforeman.org/pulpcore/3.39/el\$releasever/\$basearch/",
+      descr    => 'Pulpcore',
+      enabled  => true,
+      gpgcheck => true,
+      gpgkey   => 'https://yum.theforeman.org/pulpcore/3.39/GPG-RPM-KEY-pulpcore',
+    } ->
+    package { ['postgresql-evr']:
+      ensure  => 'absent',
+      notify  => Class['postgresql::server::service'],
+      require => Class['postgresql::server::install'],
+    }
+  }
+
   # Tune DB settings for Jenkins nodes, this is UNSAFE for production!
   $settings = {
     'fsync'                        => 'off',

--- a/puppet/modules/jenkins_node/manifests/postgresql.pp
+++ b/puppet/modules/jenkins_node/manifests/postgresql.pp
@@ -4,6 +4,7 @@ class jenkins_node::postgresql {
   if $facts['os']['family'] == 'RedHat' {
     # Necessary for PostgreSQL EVR extension
     yumrepo { 'pulpcore':
+      ensure   => 'absent',
       baseurl  => "http://yum.theforeman.org/pulpcore/3.39/el\$releasever/\$basearch/",
       descr    => 'Pulpcore',
       enabled  => true,

--- a/puppet/modules/jenkins_node/manifests/postgresql.pp
+++ b/puppet/modules/jenkins_node/manifests/postgresql.pp
@@ -1,22 +1,5 @@
 # @api private
 class jenkins_node::postgresql {
-  # only CentOS nodes are used to run unit tests
-  if $facts['os']['family'] == 'RedHat' {
-    # Necessary for PostgreSQL EVR extension
-    yumrepo { 'pulpcore':
-      baseurl  => "http://yum.theforeman.org/pulpcore/3.39/el\$releasever/\$basearch/",
-      descr    => 'Pulpcore',
-      enabled  => true,
-      gpgcheck => true,
-      gpgkey   => 'https://yum.theforeman.org/pulpcore/3.39/GPG-RPM-KEY-pulpcore',
-    } ->
-    package { ['postgresql-evr']:
-      ensure  => 'present',
-      notify  => Class['postgresql::server::service'],
-      require => Class['postgresql::server::install'],
-    }
-  }
-
   # Tune DB settings for Jenkins nodes, this is UNSAFE for production!
   $settings = {
     'fsync'                        => 'off',


### PR DESCRIPTION
We are seeing the `coper-cli's` python3-rich dependencies, which prevents from updating the latest CentOS updates. The problem is happening because of the pulp-core repos dependency in the postgresql manifests which is no longer needed.

```
Problem: package copr-cli-2.5-1.el9.noarch from @System requires python3-rich, but none of the providers can be installed
  - package python3.11-rich-13.3.1-7.el9.noarch from pulpcore obsoletes python3-rich < 13.3.1-7.el9 provided by python3-rich-13.1.0-1.el9.noarch from @System
  - package python3.11-rich-13.3.1-7.el9.noarch from pulpcore obsoletes python3-rich < 13.3.1-7.el9 provided by python3-rich-13.1.0-1.el9.noarch from epel
  - cannot install the best update candidate for package python3-rich-13.1.0-1.el9.noarch
  - cannot install the best update candidate for package copr-cli-2.5-1.el9.noarch
```