### PR TITLE
3.19 GA -> Bump version

### DIFF
--- a/puppet/data/common.yaml
+++ b/puppet/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-stable_release: '3.18'
+stable_release: '3.19'
 profiles::website::stable: '%{alias("stable_release")}'
 profiles::repo::deb::stable: '%{alias("stable_release")}'
 profiles::repo::rpm::stable_foreman: '%{alias("stable_release")}'


### PR DESCRIPTION
Foreman 3.19 was released, this patch updates the `stable_release`.
