### PR TITLE
Pin openssl to 3.5.5-3.el9 on EL9 Jenkins nodes

### DIFF
--- a/puppet/modules/jenkins_node/manifests/init.pp
+++ b/puppet/modules/jenkins_node/manifests/init.pp
@@ -22,6 +22,21 @@ class jenkins_node (
 ) {
   include fastly_purge
 
+  # Workaround for RHEL-192424: openssl-3.5.7-1 on EL9 broke TLS handling.
+  # Exclude the broken build and pin back to the last known-good NVR, following
+  # the same approach used in forklift (theforeman/forklift#1962) and
+  # foremanctl (theforeman/foremanctl#632).
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '9' {
+    file_line { 'dnf-exclude-broken-openssl':
+      path  => '/etc/dnf/dnf.conf',
+      line  => 'excludepkgs=openssl-3.5.7-1.*,openssl-libs-3.5.7-1.*,openssl-fips-provider-3.5.7-1.*',
+      match => '^excludepkgs=',
+    }
+    -> package { ['openssl', 'openssl-libs']:
+      ensure => '3.5.5-3.el9',
+    }
+  }
+
   if $facts['os']['family'] == 'RedHat' {
     $java_package = 'java-21-openjdk-headless'
 


### PR DESCRIPTION
## Summary
- openssl-3.5.7-1 on EL9 breaks TLS handling (RHEL-192424); runners are already picking it up (e.g. `openssl-libs-3.5.7-1.el9.x86_64`).
- Exclude the broken NVR via `/etc/dnf/dnf.conf` `excludepkgs` and force `openssl`/`openssl-libs` back to the last known-good `3.5.5-3.el9` build on EL9 Jenkins nodes.
- Follows the same workaround pattern used in [theforeman/forklift#1962](https://github.com/theforeman/forklift/pull/1962) and [theforeman/foremanctl#632](https://github.com/theforeman/foremanctl/pull/632).

## Test plan
- [ ] Puppet parser validate / puppet-lint pass in CI
- [ ] Apply to an EL9 Jenkins node and confirm `openssl`/`openssl-libs` downgrade to `3.5.5-3.el9` and stay pinned across subsequent runs