### PR TITLE
Revert "Pin openssl to 3.5.5-3.el9 on EL9 Jenkins nodes"

### DIFF
--- a/puppet/modules/jenkins_node/manifests/init.pp
+++ b/puppet/modules/jenkins_node/manifests/init.pp
@@ -22,22 +22,6 @@ class jenkins_node (
 ) {
   include fastly_purge
 
-  # Workaround for RHEL-192424: openssl-3.5.7-1 on EL9 broke TLS handling.
-  # Exclude the broken build and pin back to the last known-good NVR, following
-  # the same approach used in forklift (theforeman/forklift#1962) and
-  # foremanctl (theforeman/foremanctl#632).
-  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '9' {
-    file_line { 'dnf-exclude-broken-openssl':
-      ensure => absent,
-      path   => '/etc/dnf/dnf.conf',
-      line   => 'excludepkgs=openssl-3.5.7-1.*,openssl-libs-3.5.7-1.*,openssl-fips-provider-3.5.7-1.*',
-      match  => '^excludepkgs=',
-    }
-    -> package { ['openssl', 'openssl-libs']:
-      ensure => '3.5.5-3.el9',
-    }
-  }
-
   if $facts['os']['family'] == 'RedHat' {
     $java_package = 'java-21-openjdk-headless'
 


### PR DESCRIPTION
This reverts commit 026028aeaf8ab61b09c62852c02775258d04569d (#2444).

The openssl ASN1 fix is now present in CentOS Stream 9 repos, so the workaround for RHEL-192424 is no longer needed.