### PR TITLE
Install ca-certificates before pbuilder adds the NodeSource repo

### DIFF
--- a/puppet/modules/jenkins_node/files/pbuilder_D85-install-ca-certificates
+++ b/puppet/modules/jenkins_node/files/pbuilder_D85-install-ca-certificates
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Make sure ca-certificates is present before any F-hook adds a repo that
+# redirects plain HTTP to HTTPS (e.g. deb.nodesource.com). Without this,
+# apt fails with "No system certificates available" instead of falling
+# back to the distro's older package.
+
+apt-get update -qq
+apt-get install -y --no-install-recommends ca-certificates

--- a/puppet/modules/jenkins_node/files/pbuilder_F66-add-nodesource-nodistro-repos
+++ b/puppet/modules/jenkins_node/files/pbuilder_F66-add-nodesource-nodistro-repos
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "deb http://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list
+echo "deb https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list
 
 cat > /etc/apt/trusted.gpg.d/nodesource-nodistro.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
+++ b/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
@@ -41,6 +41,7 @@ define jenkins_node::pbuilder_setup (
     'A10nozstd'                         => $release == 'jammy',
     'C10foremanlog'                     => true,
     'D80no-man-db-rebuild'              => true,
+    'D85-install-ca-certificates'       => $nodesource,
     'F60addforemanrepo'                 => true,
     'F65-add-backport-repos'            => $backports,
     'F66-add-nodesource-nodistro-repos' => $nodesource,

--- a/puppet/spec/classes/jenkins_node_spec.rb
+++ b/puppet/spec/classes/jenkins_node_spec.rb
@@ -24,6 +24,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/D80no-man-db-rebuild').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/D85-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }
@@ -36,6 +37,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/D80no-man-db-rebuild').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/D85-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }
@@ -46,6 +48,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/D80no-man-db-rebuild').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/D85-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }
@@ -56,6 +59,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/D80no-man-db-rebuild').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/D85-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }


### PR DESCRIPTION
`foreman-develop-package-release` has failed every nightly run since 2026-08-18: `deb.nodesource.com` started redirecting HTTP to HTTPS, but the pbuilder chroot has no `ca-certificates` yet at that point in the build, so the TLS handshake fails, the NodeSource index gets dropped, and the distro's older `nodejs` can't satisfy `nodejs (>= 22.0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)