### PR TITLE
Move ca-certificates install from a D-hook to an F-hook

### DIFF
--- a/puppet/modules/jenkins_node/files/pbuilder_D85-install-ca-certificates
+++ b/puppet/modules/jenkins_node/files/pbuilder_D85-install-ca-certificates
@@ -1,8 +1,0 @@
-#!/bin/sh
-# Make sure ca-certificates is present before any F-hook adds a repo that
-# redirects plain HTTP to HTTPS (e.g. deb.nodesource.com). Without this,
-# apt fails with "No system certificates available" instead of falling
-# back to the distro's older package.
-
-apt-get update -qq
-apt-get install -y --no-install-recommends ca-certificates

--- a/puppet/modules/jenkins_node/files/pbuilder_F05-install-ca-certificates
+++ b/puppet/modules/jenkins_node/files/pbuilder_F05-install-ca-certificates
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Make sure ca-certificates is present before other F-hooks (F60+) add repos
+# and run apt-get update. F-hooks run in lexical order right after the chroot
+# is created, before D-hooks -- a D-hook here runs too late, after F70 has
+# already tried and failed to fetch a repo that redirects HTTP to HTTPS
+# (e.g. deb.nodesource.com), aborting with "No system certificates available".
+
+apt-get update -qq
+apt-get install -y --no-install-recommends ca-certificates

--- a/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
+++ b/puppet/modules/jenkins_node/manifests/pbuilder_setup.pp
@@ -41,7 +41,7 @@ define jenkins_node::pbuilder_setup (
     'A10nozstd'                         => $release == 'jammy',
     'C10foremanlog'                     => true,
     'D80no-man-db-rebuild'              => true,
-    'D85-install-ca-certificates'       => $nodesource,
+    'F05-install-ca-certificates'       => $nodesource,
     'F60addforemanrepo'                 => true,
     'F65-add-backport-repos'            => $backports,
     'F66-add-nodesource-nodistro-repos' => $nodesource,

--- a/puppet/spec/classes/jenkins_node_spec.rb
+++ b/puppet/spec/classes/jenkins_node_spec.rb
@@ -24,7 +24,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/D80no-man-db-rebuild').with_ensure('present') }
-          it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/D85-install-ca-certificates').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F05-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/bookworm64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }
@@ -37,7 +37,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/D80no-man-db-rebuild').with_ensure('present') }
-          it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/D85-install-ca-certificates').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F05-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/noble64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }
@@ -48,7 +48,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/D80no-man-db-rebuild').with_ensure('present') }
-          it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/D85-install-ca-certificates').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F05-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/resolute64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }
@@ -59,7 +59,7 @@ describe 'jenkins_node' do
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/A10nozstd').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/C10foremanlog').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/D80no-man-db-rebuild').with_ensure('present') }
-          it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/D85-install-ca-certificates').with_ensure('present') }
+          it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F05-install-ca-certificates').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F60addforemanrepo').with_ensure('present') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F65-add-backport-repos').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/pbuilder/trixie64/hooks/F66-add-nodesource-nodistro-repos').with_ensure('present') }


### PR DESCRIPTION
Follow-up to #2460, which shipped but didn't fix the problem: rerunning `foreman-develop-package-release` (build #3080) still failed with the same `No system certificates available` error. Turns out pbuilder runs F-hooks (F60..F99, including the apt-get update in F70) before D-hooks, not after — the opposite of what #2460 assumed — so the D85 ca-certificates install still ran too late. This renames it to `F05-install-ca-certificates` so it runs before F60 adds any repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)