### PR TITLE
discourse stable is called esr now

### DIFF
--- a/puppet/modules/discourse/templates/app.yml.epp
+++ b/puppet/modules/discourse/templates/app.yml.epp
@@ -44,7 +44,7 @@ params:
   #db_work_mem: "40MB"
 
   ## Which Git revision should this container use? (default: tests-passed)
-  version: stable
+  version: esr
 
 env:
   LANG: en_US.UTF-8


### PR DESCRIPTION
the old "stable" tag still works, but "esr" it the one people should be using now, content is the same